### PR TITLE
Fix: Ensure ellipsis in Languages column truncation

### DIFF
--- a/render/fmt.go
+++ b/render/fmt.go
@@ -6,13 +6,22 @@ import (
 
 // fmtName truncates the name if it exceeds maxWidth and adds ellipsis
 func fmtName(name string, maxWidth int) string {
-	if maxWidth <= 3 {
-		return "..."
+	ellipsis := "..."
+	ellipsisWidth := lipgloss.Width(ellipsis)
+
+	if maxWidth <= ellipsisWidth {
+		return ellipsis
 	}
 
 	if lipgloss.Width(name) <= maxWidth {
 		return name
 	}
 
-	return lipgloss.NewStyle().MaxWidth(maxWidth).Render(name)
+	targetTextVisualWidth := maxWidth - ellipsisWidth
+	if targetTextVisualWidth < 1 {
+		return ellipsis
+	}
+
+	truncatedText := lipgloss.NewStyle().MaxWidth(targetTextVisualWidth).Render(name)
+	return truncatedText + ellipsis
 }


### PR DESCRIPTION
The "Languages" column was intended to truncate overly long strings with an ellipsis (...). This change modifies the `fmtName` utility function to explicitly manage this truncation.

The function now:
- Calculates the available width for the text, reserving space for "..."
- Uses `lipgloss.NewStyle().MaxWidth()` to truncate the text to the calculated available width.
- Appends "..." to the truncated text.

This ensures that strings like "CSS, Dockerfile, GraphQL" correctly become "CSS, Dockerfile, Gra..." when the column width is constrained, matching the desired behavior.