### PR TITLE
feat: add mouse support

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,6 +208,18 @@ When previewing a file, additional keyboard shortcuts are available:
 | `PgDn`              | Page down                                                           |
 | `q` / `Esc`         | Close file preview and return to directory view                     |
 
+## 🖱️ Mouse Support
+
+Tokui also supports basic mouse interaction in any terminal that reports mouse events:
+
+| Action              | Effect                                                              |
+| ------------------- | ------------------------------------------------------------------- |
+| Scroll wheel        | Move the cursor up/down in the table, scroll previews and language lists |
+| Left click          | Select a row in the table or an item in the language selection overlay |
+| Double left click   | Enter a directory, expand/collapse a directory in tree mode, or open a file preview |
+| Double left click `..` | Go back to the parent directory                                    |
+| Click outside overlay | Close the file preview, language selection or chart overlay        |
+
 ## 🤝 Contributing
 
 Pull Requests are welcome! If you'd like to add new features or report bugs, please open an issue first to discuss your ideas.

--- a/cmd/app.go
+++ b/cmd/app.go
@@ -137,6 +137,7 @@ func runApp(_ *cobra.Command, args []string) error {
 	teaProg := tea.NewProgram(
 		vm,
 		tea.WithAltScreen(),
+		tea.WithMouseCellMotion(),
 		tea.WithoutCatchPanics(),
 	)
 

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/charmbracelet/bubbletea v1.3.4
 	github.com/charmbracelet/lipgloss v1.1.0
 	github.com/charmbracelet/x/ansi v0.8.0
+	github.com/mattn/go-runewidth v0.0.16
 	github.com/muesli/termenv v0.16.0
 	github.com/spf13/cobra v1.9.1
 )
@@ -23,7 +24,6 @@ require (
 	github.com/lucasb-eyer/go-colorful v1.2.0 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/mattn/go-localereader v0.0.1 // indirect
-	github.com/mattn/go-runewidth v0.0.16 // indirect
 	github.com/muesli/ansi v0.0.0-20230316100256-276c6243b2f6 // indirect
 	github.com/muesli/cancelreader v0.2.2 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect

--- a/render/dir_model.go
+++ b/render/dir_model.go
@@ -87,7 +87,7 @@ type DirModel struct {
 
 type mouseClick struct {
 	time time.Time
-	y    int
+	row  int
 }
 
 // overlayBounds tracks the screen position of the currently rendered overlay.
@@ -1232,10 +1232,10 @@ func (dm *DirModel) handleTableMouse(msg tea.MouseMsg) (int, int, bool) {
 		}
 		now := time.Now()
 		clickCount := 1
-		if !dm.lastClick.time.IsZero() && now.Sub(dm.lastClick.time) < doubleClickThreshold && dm.lastClick.y == msg.Y {
+		if !dm.lastClick.time.IsZero() && now.Sub(dm.lastClick.time) < doubleClickThreshold && dm.lastClick.row == row {
 			clickCount = 2
 		}
-		dm.lastClick = mouseClick{time: now, y: msg.Y}
+		dm.lastClick = mouseClick{time: now, row: row}
 		dm.dirsTable.SetCursor(row)
 		return row, clickCount, true
 	}
@@ -1262,6 +1262,7 @@ func (dm *DirModel) handleLangSelectMouse(msg tea.MouseMsg) (tea.Cmd, bool) {
 		if !dm.isInsideLangSelectBox(msg.X, msg.Y) {
 			dm.mode = READY
 			dm.selectMode = false
+			dm.updateTableData()
 			return nil, true
 		}
 		idx := dm.langSelectIndexAtY(msg.Y)

--- a/render/dir_model.go
+++ b/render/dir_model.go
@@ -9,6 +9,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/zdyxry/tokui/filter"
 	"github.com/zdyxry/tokui/structure"
@@ -16,6 +17,7 @@ import (
 	"github.com/charmbracelet/bubbles/table"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
+	"github.com/mattn/go-runewidth"
 )
 
 type Mode string
@@ -49,8 +51,9 @@ type ErrorMsg struct {
 }
 
 type tableEntry struct {
-	entry *structure.Entry
-	depth int
+	entry    *structure.Entry
+	depth    int
+	isParent bool
 }
 
 type DirModel struct {
@@ -75,7 +78,28 @@ type DirModel struct {
 	tableEntries  []*tableEntry
 	treeMode      bool
 	sortState     SortState
+
+	// Mouse support
+	overlayBounds overlayBounds
+	lastClick     mouseClick
+	lastTableView string // cached table view from the last render
 }
+
+type mouseClick struct {
+	time time.Time
+	y    int
+}
+
+// overlayBounds tracks the screen position of the currently rendered overlay.
+type overlayBounds struct {
+	kind      string // "preview", "chart" or "langselect"
+	x, y      int    // top-left corner
+	w, h      int    // width and height
+	langStart int    // first visible language index (for langselect)
+	langEnd   int    // last visible language index + 1 (for langselect)
+}
+
+const tableHeaderHeight = 2 // TableHeaderStyle has BorderBottom and no padding
 
 // NewDirModel creates and initializes a directory view model.
 func NewDirModel(nav *Navigation, tokeiVersion string, treeMode bool) *DirModel {
@@ -129,7 +153,16 @@ func (dm *DirModel) SelectedEntry() *structure.Entry {
 	if cursor < 0 || cursor >= len(dm.tableEntries) {
 		return nil
 	}
+	if dm.tableEntries[cursor].isParent {
+		return nil
+	}
 	return dm.tableEntries[cursor].entry
+}
+
+// IsParentSelected reports whether the synthetic ".." entry is selected.
+func (dm *DirModel) IsParentSelected() bool {
+	cursor := dm.dirsTable.Cursor()
+	return cursor >= 0 && cursor < len(dm.tableEntries) && dm.tableEntries[cursor].isParent
 }
 
 func (dm *DirModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
@@ -259,6 +292,17 @@ func (dm *DirModel) View() string {
 			lines = append(lines, lipgloss.NewStyle().Faint(true).Render("..."))
 		}
 		box := chartBoxStyle.Render(lipgloss.JoinVertical(lipgloss.Top, lines...))
+		boxW := lipgloss.Width(box)
+		boxH := lipgloss.Height(box)
+		dm.overlayBounds = overlayBounds{
+			kind:      "langselect",
+			x:         dm.width/2 - boxW/2,
+			y:         dm.height/2 - boxH/2,
+			w:         boxW,
+			h:         boxH,
+			langStart: start,
+			langEnd:   end,
+		}
 		bg := lipgloss.NewStyle().Width(dm.width).Height(dm.height).Render(" ")
 		return OverlayCenter(dm.width, dm.height, bg, box)
 	}
@@ -287,7 +331,8 @@ func (dm *DirModel) View() string {
 	}
 
 	dm.dirsTable.SetHeight(dirsTableHeight)
-	rows = append(rows, dm.dirsTable.View())
+	dm.lastTableView = dm.dirsTable.View()
+	rows = append(rows, dm.lastTableView)
 
 	slices.Reverse(rows)
 
@@ -296,12 +341,28 @@ func (dm *DirModel) View() string {
 	// If in preview mode, overlay the file preview
 	if dm.mode == PREVIEW && dm.filePreview != nil {
 		preview := dm.filePreview.View()
+		dm.overlayBounds = overlayBounds{
+			kind: "preview",
+			x:    dm.width/2 - dm.filePreview.width/2,
+			y:    dm.height/2 - dm.filePreview.height/2,
+			w:    dm.filePreview.width,
+			h:    dm.filePreview.height,
+		}
 		return OverlayCenter(dm.width, dm.height, bg, preview)
 	}
 
 	// If needed, overlay the chart display
 	if dm.showCart {
 		chart := dm.viewChart()
+		chartW := lipgloss.Width(chart)
+		chartH := lipgloss.Height(chart)
+		dm.overlayBounds = overlayBounds{
+			kind: "chart",
+			x:    dm.width/2 - chartW/2,
+			y:    dm.height/2 - chartH/2,
+			w:    chartW,
+			h:    chartH,
+		}
 		return OverlayCenter(dm.width, dm.height, bg, chart)
 	}
 
@@ -772,6 +833,18 @@ func (dm *DirModel) updateTableData(resetCursor ...bool) {
 			addEntry(child, 0)
 		}
 	} else {
+		// Add a synthetic ".." entry in navigation mode when not at the root.
+		if dm.nav.entryStack.len() > 0 {
+			parentEntry := &structure.Entry{Path: "..", IsDir: true}
+			dm.tableEntries = append(dm.tableEntries, &tableEntry{entry: parentEntry, isParent: true})
+			rows = append(rows, table.Row{
+				"⬆",
+				"",
+				"..",
+				"",
+				"0", "0", "0", "0", "",
+			})
+		}
 		for _, child := range dm.nav.Entry().Child {
 			if !dm.filters.Valid(child) {
 				continue
@@ -1004,6 +1077,12 @@ func (dm *DirModel) IsInPreviewMode() bool {
 	return dm.mode == PREVIEW
 }
 
+// ClosePreview closes the file preview and returns to the directory view.
+func (dm *DirModel) ClosePreview() {
+	dm.mode = READY
+	dm.filePreview = nil
+}
+
 func openFileWithEditor(filePath string) tea.Cmd {
 	editor := os.Getenv("EDITOR")
 	if editor == "" {
@@ -1015,4 +1094,183 @@ func openFileWithEditor(filePath string) tea.Cmd {
 	return tea.ExecProcess(cmd, func(err error) tea.Msg {
 		return EditorFinished{Err: err}
 	})
+}
+
+// --- Mouse support ---------------------------------------------------------
+
+const doubleClickThreshold = 300 * time.Millisecond
+
+func (dm *DirModel) isInsideOverlay(x, y int) bool {
+	b := dm.overlayBounds
+	return x >= b.x && x < b.x+b.w && y >= b.y && y < b.y+b.h
+}
+
+func (dm *DirModel) isInsidePreviewBox(x, y int) bool {
+	return dm.overlayBounds.kind == "preview" && dm.isInsideOverlay(x, y)
+}
+
+func (dm *DirModel) isInsideChartBox(x, y int) bool {
+	return dm.overlayBounds.kind == "chart" && dm.isInsideOverlay(x, y)
+}
+
+func (dm *DirModel) isInsideLangSelectBox(x, y int) bool {
+	return dm.overlayBounds.kind == "langselect" && dm.isInsideOverlay(x, y)
+}
+
+func (dm *DirModel) langSelectIndexAtY(y int) int {
+	b := dm.overlayBounds
+	if b.kind != "langselect" {
+		return -1
+	}
+	// Content starts one cell below the top border.
+	contentY := y - b.y - 1
+	if contentY < 2 {
+		return -1 // title or description line
+	}
+	listY := contentY - 2
+	if b.langStart > 0 {
+		if listY == 0 {
+			return -1 // "..." scroll indicator
+		}
+		listY--
+	}
+	idx := b.langStart + listY
+	if idx < b.langStart || idx >= b.langEnd || idx >= len(dm.languages) {
+		return -1
+	}
+	return idx
+}
+
+// tableRowAtY maps a terminal Y coordinate to a table row index.
+// It returns -1 when the coordinate is not over a data row.
+func (dm *DirModel) tableRowAtY(y int) int {
+	// Use the view from the last render; the user clicked what they saw.
+	view := dm.lastTableView
+	if view == "" {
+		view = dm.dirsTable.View()
+	}
+	lines := strings.Split(view, "\n")
+	if y < tableHeaderHeight || y >= len(lines) {
+		return -1
+	}
+	visibleIdx := y - tableHeaderHeight
+	if visibleIdx < 0 || visibleIdx >= len(lines)-tableHeaderHeight {
+		return -1
+	}
+
+	cursor := dm.dirsTable.Cursor()
+	cursorLine := dm.findCursorLineInView(view)
+	if cursorLine < 0 {
+		return -1
+	}
+
+	row := cursor + (visibleIdx - cursorLine)
+	if row < 0 || row >= len(dm.tableEntries) {
+		return -1
+	}
+	return row
+}
+
+// findCursorLineInView finds the visible line index (0-based, excluding header)
+// that corresponds to the currently selected row by comparing exactly rendered rows.
+func (dm *DirModel) findCursorLineInView(view string) int {
+	lines := strings.Split(view, "\n")
+	if len(lines) <= tableHeaderHeight {
+		return -1
+	}
+	selectedRow := dm.dirsTable.SelectedRow()
+	if selectedRow == nil {
+		return -1
+	}
+	renderedSelected := strings.TrimRight(dm.renderTableRow(selectedRow, true), " ")
+	for i := tableHeaderHeight; i < len(lines); i++ {
+		if strings.TrimRight(lines[i], " ") == renderedSelected {
+			return i - tableHeaderHeight
+		}
+	}
+	return -1
+}
+
+// renderTableRow replicates the rendering logic of bubbles/table's renderRow so
+// that we can match a data row to its exact rendered line.
+func (dm *DirModel) renderTableRow(row table.Row, selected bool) string {
+	cols := dm.dirsTable.Columns()
+	var cells []string
+	for i, value := range row {
+		if i >= len(cols) || cols[i].Width <= 0 {
+			continue
+		}
+		style := lipgloss.NewStyle().Width(cols[i].Width).MaxWidth(cols[i].Width).Inline(true)
+		renderedCell := style.Render(runewidth.Truncate(value, cols[i].Width, "…"))
+		cells = append(cells, renderedCell)
+	}
+	line := lipgloss.JoinHorizontal(lipgloss.Left, cells...)
+	if selected {
+		line = SelectedRowStyle.Render(line)
+	}
+	return line
+}
+
+// handleTableMouse handles mouse events for the main directory table.
+// It returns the selected row, the click count (2 for a double-click) and
+// whether the event was consumed.
+func (dm *DirModel) handleTableMouse(msg tea.MouseMsg) (int, int, bool) {
+	switch msg.Button {
+	case tea.MouseButtonWheelUp:
+		dm.dirsTable.MoveUp(1)
+		return -1, 0, true
+	case tea.MouseButtonWheelDown:
+		dm.dirsTable.MoveDown(1)
+		return -1, 0, true
+	case tea.MouseButtonLeft:
+		if msg.Action != tea.MouseActionPress {
+			return -1, 0, false
+		}
+		row := dm.tableRowAtY(msg.Y)
+		if row < 0 {
+			return -1, 0, false
+		}
+		now := time.Now()
+		clickCount := 1
+		if !dm.lastClick.time.IsZero() && now.Sub(dm.lastClick.time) < doubleClickThreshold && dm.lastClick.y == msg.Y {
+			clickCount = 2
+		}
+		dm.lastClick = mouseClick{time: now, y: msg.Y}
+		dm.dirsTable.SetCursor(row)
+		return row, clickCount, true
+	}
+	return -1, 0, false
+}
+
+// handleLangSelectMouse handles mouse events for the language selection overlay.
+func (dm *DirModel) handleLangSelectMouse(msg tea.MouseMsg) (tea.Cmd, bool) {
+	switch msg.Button {
+	case tea.MouseButtonWheelUp:
+		if dm.selectIndex > 0 {
+			dm.selectIndex--
+		}
+		return nil, true
+	case tea.MouseButtonWheelDown:
+		if dm.selectIndex < len(dm.languages)-1 {
+			dm.selectIndex++
+		}
+		return nil, true
+	case tea.MouseButtonLeft:
+		if msg.Action != tea.MouseActionPress {
+			return nil, false
+		}
+		if !dm.isInsideLangSelectBox(msg.X, msg.Y) {
+			dm.mode = READY
+			dm.selectMode = false
+			return nil, true
+		}
+		idx := dm.langSelectIndexAtY(msg.Y)
+		if idx >= 0 && idx < len(dm.languages) {
+			dm.selectIndex = idx
+			lang := dm.languages[idx]
+			dm.selectedLangs[lang] = !dm.selectedLangs[lang]
+		}
+		return nil, true
+	}
+	return nil, false
 }

--- a/render/file_preview.go
+++ b/render/file_preview.go
@@ -41,13 +41,13 @@ func NewFilePreview(filePath string, width, height int) *FilePreview {
 	fp := &FilePreview{
 		filePath: filePath,
 		fileName: filepath.Base(filePath),
-		width:    previewWidth,   // Use preview width instead of terminal width
-		height:   previewHeight,  // Use preview height instead of terminal height
+		width:    previewWidth,  // Use preview width instead of terminal width
+		height:   previewHeight, // Use preview height instead of terminal height
 	}
 
 	// Initialize viewport - leave space for borders, title, footer and padding
-	viewportWidth := previewWidth - 10   // Leave space for box borders and padding
-	viewportHeight := previewHeight - 8  // Leave space for title, footer and padding
+	viewportWidth := previewWidth - 10  // Leave space for box borders and padding
+	viewportHeight := previewHeight - 8 // Leave space for title, footer and padding
 	fp.viewport = viewport.New(viewportWidth, viewportHeight)
 
 	// Load file content
@@ -169,6 +169,9 @@ func (fp *FilePreview) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case tea.KeyMsg:
 		// Handle viewport navigation keys
+		fp.viewport, cmd = fp.viewport.Update(msg)
+	case tea.MouseMsg:
+		// Forward mouse events (e.g. scroll wheel) to the viewport.
 		fp.viewport, cmd = fp.viewport.Update(msg)
 	}
 

--- a/render/navigation.go
+++ b/render/navigation.go
@@ -70,7 +70,7 @@ func (n *Navigation) Up() {
 	n.entry, n.cursor = lastItem.entry, lastItem.cursor
 }
 
-func (n *Navigation) Down(name string, cursor int) {
+func (n *Navigation) Down(name string, parentCursor, childCursor int) {
 	if len(name) == 0 {
 		return
 	}
@@ -80,8 +80,8 @@ func (n *Navigation) Down(name string, cursor int) {
 		return
 	}
 
-	n.entryStack.push(&stackItem{entry: n.entry, cursor: cursor})
-	n.entry, n.cursor = entry, 0
+	n.entryStack.push(&stackItem{entry: n.entry, cursor: parentCursor})
+	n.entry, n.cursor = entry, childCursor
 }
 
 // AbsPathFromSelectedRow returns absolute path from selected row, using column 1's hidden path

--- a/render/render.go
+++ b/render/render.go
@@ -28,8 +28,7 @@ func NewViewModel(n *Navigation, dirModel *DirModel) *ViewModel {
 }
 
 func (vm *ViewModel) Init() tea.Cmd {
-	// Disable mouse events as we use keyboard-only interactions
-	return tea.DisableMouse
+	return nil
 }
 
 func (vm *ViewModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
@@ -59,15 +58,19 @@ func (vm *ViewModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 							selectedEntry.Expanded = !selectedEntry.Expanded
 							vm.dirModel.Update(ScanFinished{})
 						} else {
-							vm.nav.Down(selectedEntry.Name(), 0)
+							vm.nav.Down(selectedEntry.Name(), 0, 1)
 							vm.dirModel.Update(ScanFinished{ResetCursor: true})
 						}
 					} else {
 						vm.dirModel.ShowFilePreview(selectedEntry.Path)
 					}
+				} else if vm.dirModel.IsParentSelected() {
+					vm.levelUp()
 				}
 			} else {
-				if vm.dirModel.treeMode {
+				if vm.dirModel.IsParentSelected() {
+					vm.levelUp()
+				} else if vm.dirModel.treeMode {
 					vm.toggleExpand()
 				} else {
 					vm.levelDown()
@@ -80,6 +83,9 @@ func (vm *ViewModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 			vm.levelUp()
 		}
+
+	case tea.MouseMsg:
+		return vm.handleMouseMsg(msg)
 	}
 
 	// Pass all messages to the child model (DirModel) for processing
@@ -88,12 +94,59 @@ func (vm *ViewModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	return vm, cmd
 }
 
+func (vm *ViewModel) handleMouseMsg(msg tea.MouseMsg) (tea.Model, tea.Cmd) {
+	var cmd tea.Cmd
+
+	switch {
+	case vm.dirModel.mode == PREVIEW:
+		// Click outside the preview box closes it; wheel events scroll the viewport.
+		if msg.Button == tea.MouseButtonLeft && msg.Action == tea.MouseActionPress && !vm.dirModel.isInsidePreviewBox(msg.X, msg.Y) {
+			vm.dirModel.ClosePreview()
+			return vm, nil
+		}
+		_, cmd = vm.dirModel.filePreview.Update(msg)
+		return vm, cmd
+
+	case vm.dirModel.mode == SELECT_LANG:
+		// Consume all mouse events while the language overlay is open.
+		cmd, _ = vm.dirModel.handleLangSelectMouse(msg)
+		return vm, cmd
+
+	case vm.dirModel.showCart:
+		// Click outside the chart closes it.
+		if msg.Button == tea.MouseButtonLeft && msg.Action == tea.MouseActionPress && !vm.dirModel.isInsideChartBox(msg.X, msg.Y) {
+			vm.dirModel.showCart = false
+			return vm, nil
+		}
+		return vm, nil
+	}
+
+	row, clickCount, handled := vm.dirModel.handleTableMouse(msg)
+	if handled {
+		if clickCount >= 2 && row >= 0 {
+			if vm.dirModel.treeMode {
+				vm.toggleExpand()
+			} else {
+				vm.levelDown()
+			}
+		}
+		return vm, nil
+	}
+
+	return vm, nil
+}
+
 func (vm *ViewModel) View() string {
 	return vm.dirModel.View()
 }
 
 func (vm *ViewModel) levelDown() {
 	if vm.dirModel.dirsTable.Rows() == nil || len(vm.dirModel.dirsTable.SelectedRow()) < 3 {
+		return
+	}
+
+	if vm.dirModel.IsParentSelected() {
+		vm.levelUp()
 		return
 	}
 
@@ -107,7 +160,7 @@ func (vm *ViewModel) levelDown() {
 		return
 	}
 
-	vm.nav.Down(entryName, vm.dirModel.dirsTable.Cursor())
+	vm.nav.Down(entryName, vm.dirModel.dirsTable.Cursor(), 1)
 	vm.dirModel.Update(ScanFinished{ResetCursor: true})
 }
 


### PR DESCRIPTION
- Enable mouse via tea.WithMouseCellMotion program option
- Support scroll wheel, click-to-select, double-click-to-open
- Add synthetic .. entry for mouse navigation back to parent
- Handle mouse in preview, language selection, and chart overlays
- Fix row mapping by trimming viewport trailing padding