### PR TITLE
feat: polish status bar with better formatting and responsive layout

### DIFF
--- a/render/dir_model.go
+++ b/render/dir_model.go
@@ -1001,21 +1001,49 @@ func (dm *DirModel) dirsSummary() string {
 	if dm.treeMode {
 		modeStr = "Tree"
 	}
-	items := []*BarItem{
-		NewBarItem(dm.tokeiVersion, "#8338ec", 0),
+
+	codeStr := formatNumber(currentStats.Code)
+	totalStr := formatNumber(currentStats.Total())
+	if currentStats.Total() > 0 {
+		codeStr = fmt.Sprintf("%s (%d%%)", codeStr, currentStats.Code*100/currentStats.Total())
+	}
+
+	// Build the status bar from most to least important. Lower-priority items
+	// are hidden on narrow terminals so the path and core metrics remain readable.
+	const (
+		showVersionMinWidth = 110
+		showSortMinWidth    = 130
+	)
+
+	items := make([]*BarItem, 0, 12)
+
+	if dm.width >= showVersionMinWidth {
+		items = append(items, NewBarItem(fmt.Sprintf("tokei %s", dm.tokeiVersion), "#8338ec", 0))
+	}
+
+	items = append(items,
 		NewBarItem("PATH", "#FF5F87", 0),
 		NewBarItem(dm.nav.Entry().Path, "", -1),
-		NewBarItem("MODE", "#06ffa5", 0),
+		NewBarItem("MODE", "#06b6d4", 0),
 		NewBarItem(modeStr, "", 0),
-		NewBarItem("LANG FILTER", "#3a86ff", 0),
+		NewBarItem("LANG", "#3a86ff", 0),
 		NewBarItem(dm.statusLangLabel(), "", 0),
-		NewBarItem("SORT", "#06ffa5", 0),
-		NewBarItem(fmt.Sprintf("%s %s", dm.sortState.Key, dm.sortState.DirectionArrow()), "", 0),
-		NewBarItem("CODE", "#fb5607", 0),
-		DefaultBarItem(strconv.FormatInt(currentStats.Code, 10)),
-		NewBarItem("TOTAL", "#ffbe0b", 0),
-		DefaultBarItem(strconv.FormatInt(currentStats.Total(), 10)),
+	)
+
+	if dm.width >= showSortMinWidth {
+		items = append(items,
+			NewBarItem("SORT", "#14b8a6", 0),
+			NewBarItem(fmt.Sprintf("%s %s", dm.sortState.Key, dm.sortState.DirectionArrow()), "", 0),
+		)
 	}
+
+	items = append(items,
+		NewBarItem("CODE", "#fb5607", 0),
+		DefaultBarItem(codeStr),
+		NewBarItem("TOTAL", "#ffbe0b", 0),
+		DefaultBarItem(totalStr),
+	)
+
 	return statusBarStyle.Margin(1, 0, 0, 0).Render(NewStatusBar(items, dm.width))
 }
 

--- a/render/fmt.go
+++ b/render/fmt.go
@@ -1,8 +1,42 @@
 package render
 
 import (
+	"strconv"
+
 	"github.com/charmbracelet/lipgloss"
+	"github.com/mattn/go-runewidth"
 )
+
+// formatNumber adds thousands separators to an integer for easier reading.
+func formatNumber(n int64) string {
+	in := strconv.FormatInt(n, 10)
+	start := 0
+	if n < 0 {
+		start = 1
+	}
+	out := make([]byte, 0, len(in)+len(in)/3)
+	if n < 0 {
+		out = append(out, '-')
+	}
+	for i := start; i < len(in); i++ {
+		if i > start && (len(in)-i)%3 == 0 {
+			out = append(out, ',')
+		}
+		out = append(out, in[i])
+	}
+	return string(out)
+}
+
+// truncateVisual truncates s to fit within maxWidth visual cells.
+func truncateVisual(s string, maxWidth int) string {
+	if maxWidth <= 0 {
+		return ""
+	}
+	if runewidth.StringWidth(s) <= maxWidth {
+		return s
+	}
+	return runewidth.Truncate(s, maxWidth, "")
+}
 
 // fmtName truncates the name if it exceeds maxWidth and adds ellipsis
 func fmtName(name string, maxWidth int) string {

--- a/render/fmt_test.go
+++ b/render/fmt_test.go
@@ -1,0 +1,79 @@
+package render
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/charmbracelet/lipgloss"
+)
+
+func TestFormatNumber(t *testing.T) {
+	cases := []struct {
+		in   int64
+		want string
+	}{
+		{0, "0"},
+		{1, "1"},
+		{999, "999"},
+		{1000, "1,000"},
+		{1234567, "1,234,567"},
+		{-1, "-1"},
+		{-12, "-12"},
+		{-123, "-123"},
+		{-1234, "-1,234"},
+		{-123456, "-123,456"},
+		{-1234567, "-1,234,567"},
+	}
+
+	for _, c := range cases {
+		if got := formatNumber(c.in); got != c.want {
+			t.Errorf("formatNumber(%d) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}
+
+func TestTruncateVisual(t *testing.T) {
+	cases := []struct {
+		s       string
+		max     int
+		want    string
+		wantLen int
+	}{
+		{"hello", 0, "", 0},
+		{"hello", 2, "he", 2},
+		{"hello", 5, "hello", 5},
+		{"hello", 10, "hello", 5},
+		{"中文测试", 4, "中文", 4},
+	}
+
+	for _, c := range cases {
+		got := truncateVisual(c.s, c.max)
+		if got != c.want {
+			t.Errorf("truncateVisual(%q, %d) = %q, want %q", c.s, c.max, got, c.want)
+		}
+		if w := lipgloss.Width(got); w != c.wantLen {
+			t.Errorf("truncateVisual(%q, %d) width = %d, want %d", c.s, c.max, w, c.wantLen)
+		}
+	}
+}
+
+func TestNewStatusBarDynamicWidthDoesNotWrap(t *testing.T) {
+	items := []*BarItem{
+		NewBarItem("PATH", "#FF5F87", 0),
+		NewBarItem("/very/long/path/that/could/wrap", "", -1),
+		NewBarItem("MODE", "#06b6d4", 0),
+		DefaultBarItem("Nav"),
+	}
+
+	const totalWidth = 40
+	rendered := NewStatusBar(items, totalWidth)
+
+	// The rendered status bar should not exceed the requested total width,
+	// and should not contain newline characters from wrapping content.
+	if lipgloss.Width(rendered) > totalWidth {
+		t.Errorf("status bar width %d exceeds total width %d", lipgloss.Width(rendered), totalWidth)
+	}
+	if strings.Contains(rendered, "\n") {
+		t.Errorf("status bar should not wrap to multiple lines:\n%s", rendered)
+	}
+}

--- a/render/status_bar.go
+++ b/render/status_bar.go
@@ -87,13 +87,27 @@ func NewStatusBar(items []*BarItem, totalWidth int) string {
 		maxItemWidth = int(
 			math.Ceil(float64(totalWidth) / float64(len(toMaxWidth))),
 		)
+		if maxItemWidth < 0 {
+			maxItemWidth = 0
+		}
 	}
 
 	for i := range items {
 		style := styles[i]
 
 		if _, ok := toMaxWidth[i]; ok {
-			style = style.Width(min(totalWidth, maxItemWidth))
+			w := min(totalWidth, maxItemWidth)
+			if w < 0 {
+				w = 0
+			}
+			style = style.Width(w)
+
+			// Truncate the content so it cannot wrap beyond the allocated width.
+			contentMaxWidth := style.GetWidth() - style.GetHorizontalFrameSize()
+			if contentMaxWidth < 0 {
+				contentMaxWidth = 0
+			}
+			items[i].content = truncateVisual(items[i].content, contentMaxWidth)
 
 			totalWidth -= style.GetWidth()
 		}


### PR DESCRIPTION
- Add thousands separators to CODE/TOTAL counts
- Show code percentage in status bar
- Label tokei version explicitly
- Shorten LANG FILTER to LANG
- Use distinct colors for MODE and SORT
- Hide version/SORT on narrow terminals
- Truncate dynamic-width segments to prevent wrapping
- Add unit tests for formatting helpers