### PR TITLE
fix: close preview with q without quitting

### DIFF
--- a/render/dir_model_test.go
+++ b/render/dir_model_test.go
@@ -3,6 +3,7 @@ package render
 import (
 	"testing"
 
+	tea "github.com/charmbracelet/bubbletea"
 	"github.com/zdyxry/tokui/structure"
 )
 
@@ -205,5 +206,24 @@ func TestDirModelToggleSortOrder(t *testing.T) {
 	}
 	if dm.sortState.Key != SortByTotal {
 		t.Errorf("expected key to remain %q", SortByTotal)
+	}
+}
+
+func TestViewModelPreviewQClosesPreviewWithoutQuitting(t *testing.T) {
+	dm := newTestDirModel()
+	dm.mode = PREVIEW
+	dm.filePreview = &FilePreview{}
+	vm := NewViewModel(nil, dm)
+
+	_, cmd := vm.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'q'}})
+
+	if cmd != nil {
+		t.Fatalf("expected q in preview mode not to quit")
+	}
+	if dm.mode != READY {
+		t.Fatalf("expected q to return to ready mode, got %v", dm.mode)
+	}
+	if dm.filePreview != nil {
+		t.Fatalf("expected q to close preview")
 	}
 }

--- a/render/dir_model_test.go
+++ b/render/dir_model_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	tea "github.com/charmbracelet/bubbletea"
+	"github.com/zdyxry/tokui/filter"
 	"github.com/zdyxry/tokui/structure"
 )
 
@@ -225,5 +226,25 @@ func TestViewModelPreviewQClosesPreviewWithoutQuitting(t *testing.T) {
 	}
 	if dm.filePreview != nil {
 		t.Fatalf("expected q to close preview")
+	}
+}
+
+func TestViewModelInputQFiltersWithoutQuitting(t *testing.T) {
+	testDM := newTestDirModel()
+	dm := NewDirModel(NewCodeNavigation(structure.NewTree(testDM.nav.Entry())), "", false, false)
+	dm.mode = INPUT
+	dm.filters.ToggleFilter(filter.NameFilterID)
+	vm := NewViewModel(nil, dm)
+
+	_, cmd := vm.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'q'}})
+
+	if cmd != nil {
+		t.Fatalf("expected q in input mode not to quit")
+	}
+	if dm.mode != INPUT {
+		t.Fatalf("expected q to keep input mode, got %v", dm.mode)
+	}
+	if got := len(dm.dirsTable.Rows()); got != 0 {
+		t.Fatalf("expected q to be applied to the name filter, got %d rows", got)
 	}
 }

--- a/render/render.go
+++ b/render/render.go
@@ -47,10 +47,9 @@ func (vm *ViewModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 		switch bk {
 		case quit:
-			if vm.dirModel.mode == PREVIEW {
-				break
+			if vm.dirModel.mode != PREVIEW && vm.dirModel.mode != INPUT {
+				return vm, tea.Quit
 			}
-			return vm, tea.Quit
 		case cancel:
 			return vm, tea.Quit
 		case enter:

--- a/render/render.go
+++ b/render/render.go
@@ -46,7 +46,12 @@ func (vm *ViewModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		bk := bindingKey(strings.ToLower(msg.String()))
 
 		switch bk {
-		case quit, cancel:
+		case quit:
+			if vm.dirModel.mode == PREVIEW {
+				break
+			}
+			return vm, tea.Quit
+		case cancel:
 			return vm, tea.Quit
 		case enter:
 			if vm.dirModel.mode == INPUT {


### PR DESCRIPTION
## Summary
- Keep q from triggering the top-level quit handler while file preview is open
- Let the existing preview handler close the preview instead
- Add a regression test for q in preview mode

## Tests
- go test ./...