### PR TITLE
feat(treemap): nested treemap with dynamic depth and keyboard navigation

### DIFF
--- a/render/dir_model.go
+++ b/render/dir_model.go
@@ -504,14 +504,10 @@ func (dm *DirModel) handleKeyBindings(msg tea.KeyMsg) (tea.Cmd, bool) {
 	if dm.treemapMode {
 		switch bk {
 		case "up", "k":
-			if dm.treemapSelected > 0 {
-				dm.treemapSelected--
-			}
+			dm.moveTreemapSelection(-1)
 			return nil, true
 		case "down", "j":
-			if dm.treemapSelected < len(dm.treemapBlocks)-1 {
-				dm.treemapSelected++
-			}
+			dm.moveTreemapSelection(1)
 			return nil, true
 		case toggleTree:
 			// Switch from treemap view back to tree table view.
@@ -1193,6 +1189,55 @@ func (dm *DirModel) viewTreemap(availableHeight int) string {
 		view, _ = Treemap(w, h, children, getSize, dm.treemapSelected)
 	}
 	return view
+}
+
+// moveTreemapSelection moves the keyboard selection among top-level (level 0)
+// treemap blocks. Nested blocks can still be selected with the mouse, but j/k
+// always stay at the current directory's immediate children.
+func (dm *DirModel) moveTreemapSelection(delta int) {
+	if len(dm.treemapBlocks) == 0 {
+		return
+	}
+
+	// Collect indices of all top-level blocks in display order.
+	topIdxs := make([]int, 0)
+	for i, b := range dm.treemapBlocks {
+		if b.level == 0 {
+			topIdxs = append(topIdxs, i)
+		}
+	}
+	if len(topIdxs) == 0 {
+		return
+	}
+
+	// Find the current position among top-level blocks.
+	currentTop := dm.treemapSelected
+	if currentTop < 0 || currentTop >= len(dm.treemapBlocks) {
+		currentTop = dm.treemapBlocks[topIdxs[0]].topIdx
+	} else {
+		currentTop = dm.treemapBlocks[currentTop].topIdx
+	}
+
+	pos := -1
+	for i, top := range topIdxs {
+		if dm.treemapBlocks[top].topIdx == currentTop {
+			pos = i
+			break
+		}
+	}
+	if pos < 0 {
+		pos = 0
+	}
+
+	pos += delta
+	if pos < 0 {
+		pos = 0
+	}
+	if pos >= len(topIdxs) {
+		pos = len(topIdxs) - 1
+	}
+
+	dm.treemapSelected = topIdxs[pos]
 }
 
 func (dm *DirModel) viewChart() string {

--- a/render/dir_model_test.go
+++ b/render/dir_model_test.go
@@ -207,3 +207,40 @@ func TestDirModelToggleSortOrder(t *testing.T) {
 		t.Errorf("expected key to remain %q", SortByTotal)
 	}
 }
+
+func TestTreemapKeyboardStaysAtTopLevel(t *testing.T) {
+	dm := &DirModel{
+		treemapMode: true,
+		treemapBlocks: []treemapBlock{
+			{entry: &structure.Entry{Path: "a"}, level: 0, topIdx: 0},
+			{entry: &structure.Entry{Path: "a1"}, level: 1, topIdx: 0},
+			{entry: &structure.Entry{Path: "a2"}, level: 1, topIdx: 0},
+			{entry: &structure.Entry{Path: "b"}, level: 0, topIdx: 1},
+			{entry: &structure.Entry{Path: "b1"}, level: 1, topIdx: 1},
+			{entry: &structure.Entry{Path: "c"}, level: 0, topIdx: 2},
+		},
+		treemapSelected: 0,
+	}
+
+	dm.moveTreemapSelection(1)
+	if dm.treemapSelected != 3 {
+		t.Fatalf("expected selection to move to top-level b (index 3), got %d", dm.treemapSelected)
+	}
+
+	dm.moveTreemapSelection(1)
+	if dm.treemapSelected != 5 {
+		t.Fatalf("expected selection to move to top-level c (index 5), got %d", dm.treemapSelected)
+	}
+
+	dm.moveTreemapSelection(-1)
+	if dm.treemapSelected != 3 {
+		t.Fatalf("expected selection to move back to top-level b (index 3), got %d", dm.treemapSelected)
+	}
+
+	// Starting from a nested block, j/k should still move between top-level blocks.
+	dm.treemapSelected = 1 // a1
+	dm.moveTreemapSelection(1)
+	if dm.treemapSelected != 3 {
+		t.Fatalf("expected selection from nested block to jump to top-level b (index 3), got %d", dm.treemapSelected)
+	}
+}

--- a/render/render.go
+++ b/render/render.go
@@ -1,6 +1,7 @@
 package render
 
 import (
+	"path/filepath"
 	"strings"
 
 	"github.com/charmbracelet/bubbles/help"
@@ -189,7 +190,30 @@ func (vm *ViewModel) treemapDrillDown() {
 		return
 	}
 	if entry.IsDir {
-		vm.nav.Down(entry.Name(), vm.dirModel.treemapSelected, 0)
+		// The selected block may be a nested directory. Walk from the current
+		// navigation entry down through each path component.
+		currentPath := vm.nav.Entry().Path
+		rel, err := filepath.Rel(currentPath, entry.Path)
+		if err != nil {
+			return
+		}
+		parts := strings.Split(rel, string(filepath.Separator))
+		var names []string
+		for _, p := range parts {
+			if p != "" && p != "." {
+				names = append(names, p)
+			}
+		}
+		if len(names) == 0 {
+			return
+		}
+		for i, name := range names {
+			parentCursor := 0
+			if i == 0 {
+				parentCursor = vm.dirModel.treemapSelected
+			}
+			vm.nav.Down(name, parentCursor, 0)
+		}
 		vm.dirModel.treemapSelected = 0
 		vm.dirModel.Update(ScanFinished{ResetCursor: true})
 	} else {

--- a/render/treemap.go
+++ b/render/treemap.go
@@ -3,6 +3,7 @@ package render
 import (
 	"fmt"
 	"sort"
+	"strconv"
 	"strings"
 
 	"github.com/zdyxry/tokui/structure"
@@ -22,25 +23,41 @@ type treemapItem struct {
 }
 
 // treemapBlock associates a laid-out rectangle with its source entry and label.
+// Nested treemaps are supported: a top-level block (level 0) may contain
+// child blocks (level 1+) that layout the directory's immediate children.
+// topIdx tracks which top-level block a nested block belongs to so keyboard
+// navigation can stay at the top level while mouse selection can reach nested
+// tiles.
 type treemapBlock struct {
-	entry *structure.Entry
-	rect  treemapRect
-	label string
+	entry  *structure.Entry
+	rect   treemapRect
+	label  string
+	level  int
+	color  lipgloss.Color
+	topIdx int
 }
 
-// treemapColors is the color cycle used for treemap tiles.
-// These are deliberately low-saturation, terminal-friendly colors so the
-// treemap is easy on the eyes while still making adjacent blocks distinguishable.
+// Constants controlling nested treemap layout.
+const (
+	treemapMaxNestedDepth = 5 // safety cap to avoid runaway recursion
+	minNestedWidth        = 12
+	minNestedHeight       = 7
+	minNestedItems        = 2
+)
+
+// treemapColors is the color cycle used for top-level treemap tiles.
+// The palette is saturated enough to distinguish neighbors but not so
+// bright that nested tiles become harsh on the eyes.
 var treemapColors = []lipgloss.Color{
-	"#7B9E89", // sage green
-	"#7A8B99", // slate blue
-	"#A98B6A", // muted amber
-	"#8F7B9A", // dusty purple
-	"#6A9A9A", // teal
-	"#B88A7A", // terracotta
-	"#8E9B7B", // olive
-	"#9A8B7A", // warm gray
-	"#7B8FA3", // steel blue
+	"#3498DB", // peter river blue
+	"#2ECC71", // emerald green
+	"#F39C12", // orange
+	"#9B59B6", // amethyst purple
+	"#1ABC9C", // turquoise
+	"#E74C3C", // alizarin red
+	"#F1C40F", // sunflower yellow
+	"#E67E22", // carrot orange
+	"#16A085", // green sea
 }
 
 // treemapSelectedBorder is used to outline the currently selected tile.
@@ -60,6 +77,10 @@ type treemapCell struct {
 }
 
 // Treemap renders a squarified treemap for the current directory's children.
+// For directories that occupy enough space, their immediate children are laid
+// out as nested tiles (up to treemapMaxNestedDepth levels deep) so large tiles
+// do not waste screen real-estate.
+//
 // It returns the rendered string and the list of layout blocks, which the
 // caller can use for keyboard/mouse selection.
 func Treemap(width, height int, children []*structure.Entry, getSize func(*structure.Entry) int64, selectedIdx int) (string, []treemapBlock) {
@@ -106,32 +127,35 @@ func Treemap(width, height int, children []*structure.Entry, getSize func(*struc
 	// Compute squarified layout.
 	rects := squarify(items, total, treemapRect{0, 0, width, height})
 
-	// Build display blocks (labels, etc.).
-	blocks := make([]treemapBlock, 0, len(items))
+	// Build top-level blocks.
+	topBlocks := make([]treemapBlock, 0, len(items))
 	for i, it := range items {
 		r := rects[i]
 		if r.w <= 0 || r.h <= 0 {
 			continue
 		}
 
-		var label string
-		if it.entry != nil {
-			name := it.entry.Name()
-			if it.entry.IsDir {
-				name += "/"
-			}
-			label = fmt.Sprintf("%s %s", name, formatNumber(it.size))
-		} else {
-			label = fmt.Sprintf("other %s", formatNumber(it.size))
-		}
-		blocks = append(blocks, treemapBlock{
-			entry: it.entry,
-			rect:  r,
-			label: label,
+		label := buildLabel(it.entry, it.size)
+		color := treemapColors[i%len(treemapColors)]
+		topBlocks = append(topBlocks, treemapBlock{
+			entry:  it.entry,
+			rect:   r,
+			label:  label,
+			level:  0,
+			color:  color,
+			topIdx: i,
 		})
 	}
 
-	// Draw the grid.
+	// Build nested blocks for directories that have enough room.
+	allBlocks := make([]treemapBlock, 0, len(topBlocks)*2)
+	for i := range topBlocks {
+		allBlocks = append(allBlocks, topBlocks[i])
+		buildNested(&allBlocks, len(allBlocks)-1, getSize, 1)
+	}
+
+	// Draw the grid. Parents are drawn before children so child borders and
+	// labels render on top and create a layered effect.
 	grid := make([][]treemapCell, height)
 	for y := 0; y < height; y++ {
 		grid[y] = make([]treemapCell, width)
@@ -140,10 +164,9 @@ func Treemap(width, height int, children []*structure.Entry, getSize func(*struc
 		}
 	}
 
-	for i, b := range blocks {
-		color := treemapColors[i%len(treemapColors)]
+	for i, b := range allBlocks {
 		selected := i == selectedIdx
-		fillRect(grid, b.rect, color)
+		fillRect(grid, b.rect, b.color)
 		drawBorder(grid, b.rect, selected)
 		placeLabel(grid, b.rect, b.label, selected)
 	}
@@ -166,7 +189,152 @@ func Treemap(width, height int, children []*structure.Entry, getSize func(*struc
 		lines[y] = sb.String()
 	}
 
-	return strings.Join(lines, "\n"), blocks
+	return strings.Join(lines, "\n"), allBlocks
+}
+
+// buildNested lays out children inside a directory block when there is enough
+// space, then recurses up to treemapMaxNestedDepth.
+func buildNested(allBlocks *[]treemapBlock, parentIdx int, getSize func(*structure.Entry) int64, level int) {
+	if level > treemapMaxNestedDepth {
+		return
+	}
+	parent := (*allBlocks)[parentIdx]
+	if parent.entry == nil || !parent.entry.IsDir {
+		return
+	}
+
+	bounds := nestedBounds(parent.rect)
+	if !canNest(level, bounds) {
+		return
+	}
+
+	items := make([]treemapItem, 0)
+	var total int64
+	for _, c := range parent.entry.Child {
+		if c == nil {
+			continue
+		}
+		sz := getSize(c)
+		if sz > 0 {
+			items = append(items, treemapItem{entry: c, size: sz})
+			total += sz
+		}
+	}
+	if len(items) < minNestedItems || total == 0 {
+		return
+	}
+
+	sort.Slice(items, func(i, j int) bool { return items[i].size > items[j].size })
+
+	maxItems := (bounds.w * bounds.h) / 8
+	if maxItems < minNestedItems {
+		maxItems = minNestedItems
+	}
+	if len(items) > maxItems {
+		var otherSize int64
+		for i := maxItems - 1; i < len(items); i++ {
+			otherSize += items[i].size
+		}
+		items = items[:maxItems-1]
+		items = append(items, treemapItem{entry: nil, size: otherSize})
+	}
+
+	rects := squarify(items, total, bounds)
+	startIdx := len(*allBlocks)
+	for i, it := range items {
+		r := rects[i]
+		if r.w <= 0 || r.h <= 0 {
+			continue
+		}
+
+		label := buildLabel(it.entry, it.size)
+		// Children inherit the parent's hue family so nested tiles feel cohesive.
+		// Each deeper level darkens slightly, and siblings alternate a tiny bit
+		// so adjacent rectangles remain distinguishable.
+		shift := float64(i%2)*0.06 - 0.03
+		color := adjustColor(parent.color, -0.05+shift)
+		*allBlocks = append(*allBlocks, treemapBlock{
+			entry:  it.entry,
+			rect:   r,
+			label:  label,
+			level:  level,
+			color:  color,
+			topIdx: parent.topIdx,
+		})
+	}
+
+	// Only recurse into the blocks we just added at this level. The slice
+	// grows during deeper recursion, so we must freeze the loop bound here.
+	endIdx := len(*allBlocks)
+	for i := startIdx; i < endIdx; i++ {
+		buildNested(allBlocks, i, getSize, level+1)
+	}
+}
+
+// canNest decides whether a directory tile has enough room to show its
+// children at the requested nesting level. Deeper levels require exponentially
+// more space so small tiles do not become unreadably crowded.
+func canNest(level int, bounds treemapRect) bool {
+	if bounds.w < minNestedWidth || bounds.h < minNestedHeight {
+		return false
+	}
+	// Level 1 needs the base area; each deeper level needs twice as much.
+	minArea := (minNestedWidth * minNestedHeight) * (1 << (level - 1))
+	return bounds.w*bounds.h >= minArea
+}
+
+// nestedBounds returns the inner rectangle available for laying out a parent
+// directory's children. It reserves space for the parent's border and label.
+func nestedBounds(r treemapRect) treemapRect {
+	return treemapRect{
+		x: r.x + 1,
+		y: r.y + 2,
+		w: r.w - 2,
+		h: r.h - 3,
+	}
+}
+
+// buildLabel creates a human-readable label for a treemap item.
+func buildLabel(entry *structure.Entry, size int64) string {
+	if entry != nil {
+		name := entry.Name()
+		if entry.IsDir {
+			name += "/"
+		}
+		return fmt.Sprintf("%s %s", name, formatNumber(size))
+	}
+	return fmt.Sprintf("other %s", formatNumber(size))
+}
+
+// adjustColor lightens (percent > 0) or darkens (percent < 0) a hex
+// lipgloss.Color. Nested tiles are lightened so they stand out inside their
+// parent instead of turning muddy.
+func adjustColor(c lipgloss.Color, percent float64) lipgloss.Color {
+	s := string(c)
+	if len(s) != 7 || s[0] != '#' {
+		return c
+	}
+	r, err1 := strconv.ParseInt(s[1:3], 16, 64)
+	g, err2 := strconv.ParseInt(s[3:5], 16, 64)
+	b, err3 := strconv.ParseInt(s[5:7], 16, 64)
+	if err1 != nil || err2 != nil || err3 != nil {
+		return c
+	}
+	adj := func(v int64) int64 {
+		if percent > 0 {
+			v = int64(float64(v) + (255.0-float64(v))*percent)
+		} else {
+			v = int64(float64(v) * (1 + percent))
+		}
+		if v < 0 {
+			v = 0
+		}
+		if v > 255 {
+			v = 255
+		}
+		return v
+	}
+	return lipgloss.Color(fmt.Sprintf("#%02x%02x%02x", adj(r), adj(g), adj(b)))
 }
 
 // squarify recursively lays out items into near-square rectangles.
@@ -364,14 +532,20 @@ func setCell(grid [][]treemapCell, x, y int, ch rune, fg, bg lipgloss.Color) {
 	}
 }
 
-// treemapBlockAt returns the index of the block containing the given cell
-// coordinates, or -1 if none.
+// treemapBlockAt returns the index of the innermost block containing the given
+// cell coordinates, or -1 if none. Nested blocks take precedence over their
+// parents so clicks select the actual tile the user points at.
 func treemapBlockAt(blocks []treemapBlock, x, y int) int {
+	best := -1
+	bestLevel := -1
 	for i, b := range blocks {
 		r := b.rect
 		if x >= r.x && x < r.x+r.w && y >= r.y && y < r.y+r.h {
-			return i
+			if b.level > bestLevel {
+				bestLevel = b.level
+				best = i
+			}
 		}
 	}
-	return -1
+	return best
 }

--- a/render/treemap_test.go
+++ b/render/treemap_test.go
@@ -61,3 +61,81 @@ func TestTreemapBlockAt(t *testing.T) {
 		t.Fatalf("expected no block, got %d", got)
 	}
 }
+
+func TestTreemapNestedBlocks(t *testing.T) {
+	bigDir := &structure.Entry{
+		Path:       "big",
+		IsDir:      true,
+		TotalStats: structure.CodeStats{Code: 1000},
+		Child: []*structure.Entry{
+			{Path: "a.go", IsDir: false, TotalStats: structure.CodeStats{Code: 400}},
+			{Path: "b.go", IsDir: false, TotalStats: structure.CodeStats{Code: 300}},
+			{Path: "c.go", IsDir: false, TotalStats: structure.CodeStats{Code: 300}},
+		},
+	}
+	smallDir := &structure.Entry{
+		Path:       "small",
+		IsDir:      true,
+		TotalStats: structure.CodeStats{Code: 100},
+		Child: []*structure.Entry{
+			{Path: "x.go", IsDir: false, TotalStats: structure.CodeStats{Code: 100}},
+		},
+	}
+	children := []*structure.Entry{bigDir, smallDir}
+
+	getSize := func(e *structure.Entry) int64 { return e.TotalStats.Total() }
+	view, blocks := Treemap(60, 30, children, getSize, 0)
+
+	if view == "" {
+		t.Fatal("Treemap returned empty view")
+	}
+
+	// Should contain top-level blocks plus nested children of the large directory.
+	if len(blocks) <= len(children) {
+		t.Fatalf("expected nested blocks, got %d total blocks", len(blocks))
+	}
+
+	// Find the nested child blocks.
+	hasA, hasB, hasC := false, false, false
+	for _, b := range blocks {
+		if b.entry == nil {
+			continue
+		}
+		switch b.entry.Path {
+		case "a.go":
+			hasA = true
+		case "b.go":
+			hasB = true
+		case "c.go":
+			hasC = true
+		}
+	}
+	if !hasA || !hasB || !hasC {
+		t.Fatalf("expected nested a.go/b.go/c.go blocks, got a=%v b=%v c=%v", hasA, hasB, hasC)
+	}
+
+	// Find the top-level block for the big directory.
+	var bigRect treemapRect
+	for _, b := range blocks {
+		if b.entry == bigDir {
+			bigRect = b.rect
+			break
+		}
+	}
+	if bigRect.w == 0 {
+		t.Fatal("could not find top-level block for big directory")
+	}
+
+	// Clicking inside the nested area should select the inner block, not the parent.
+	inner := treemapBlockAt(blocks, bigRect.x+3, bigRect.y+4)
+	if inner < 0 || blocks[inner].level == 0 {
+		t.Fatalf("expected nested block at inner coordinates, got %d (level %d)", inner, blocks[inner].level)
+	}
+
+	// Each nested block should remember which top-level block it belongs to.
+	for _, b := range blocks {
+		if b.level > 0 && b.topIdx < 0 {
+			t.Fatalf("nested block %v missing topIdx", b.entry)
+		}
+	}
+}


### PR DESCRIPTION
- Layout children inside large directory tiles when space permits
- Cap nesting depth dynamically based on available area
- Fix recursion bug that caused unbounded nesting
- Keep j/k keyboard navigation at the top-level directory children
- Allow mouse selection of nested tiles
- Improve color scheme: inherit parent hue and darken slightly per level