### PR TITLE
feat: add global fuzzy search with Ctrl+P

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ Flags:
 | `Tab`               | Cycle through language filters                                      |
 | `Ctrl`+`L`          | Open multi-language selection overlay                               |
 | `/`                 | Activate file name filter (press `Esc` to exit filter mode)         |
+| `Ctrl`+`P`          | Open global fuzzy search (press `Enter` to jump, `Esc` to close)    |
 | `s`                 | Cycle sort column (Name → Languages → Code → Comments → Blanks → Total → % of Parent) |
 | `S`                 | Toggle ascending / descending order for the current sort column     |
 | `Ctrl`+`w`          | Show/hide language distribution pie chart                           |

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/charmbracelet/x/ansi v0.8.0
 	github.com/mattn/go-runewidth v0.0.16
 	github.com/muesli/termenv v0.16.0
+	github.com/sahilm/fuzzy v0.1.1
 	github.com/spf13/cobra v1.9.1
 )
 
@@ -29,7 +30,7 @@ require (
 	github.com/rivo/uniseg v0.4.7 // indirect
 	github.com/spf13/pflag v1.0.6 // indirect
 	github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e // indirect
-	golang.org/x/sync v0.11.0 // indirect
+	golang.org/x/sync v0.16.0 // indirect
 	golang.org/x/sys v0.32.0 // indirect
 	golang.org/x/text v0.3.8 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -27,6 +27,8 @@ github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f h1:Y/CXytFA4m6
 github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f/go.mod h1:vw97MGsxSvLiUE2X8qFplwetxpGLQrlU1Q9AUEIzCaM=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
+github.com/kylelemons/godebug v1.1.0 h1:RPNrshWIDI6G2gRW9EHilWtl7Z6Sb1BR0xunSBf0SNc=
+github.com/kylelemons/godebug v1.1.0/go.mod h1:9/0rRGxNHcop5bhtWyNeEfOS8JIWk580+fNqagV/RAw=
 github.com/lucasb-eyer/go-colorful v1.2.0 h1:1nnpGOrhyZZuNyfu1QjKiUICQ74+3FNCN69Aj6K7nkY=
 github.com/lucasb-eyer/go-colorful v1.2.0/go.mod h1:R4dSotOR9KMtayYi1e77YzuveK+i7ruzyGqttikkLy0=
 github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=
@@ -45,6 +47,8 @@ github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJ
 github.com/rivo/uniseg v0.4.7 h1:WUdvkW8uEhrYfLC4ZzdpI2ztxP1I582+49Oc5Mq64VQ=
 github.com/rivo/uniseg v0.4.7/go.mod h1:FN3SvrM+Zdj16jyLfmOkMNblXMcoc8DfTHruCPUcx88=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
+github.com/sahilm/fuzzy v0.1.1 h1:ceu5RHF8DGgoi+/dR5PsECjCDH1BE3Fnmpo7aVXOdRA=
+github.com/sahilm/fuzzy v0.1.1/go.mod h1:VFvziUEIMCrT6A6tw2RFIXPXXmzXbOsSHF0DOI8ZK9Y=
 github.com/spf13/cobra v1.9.1 h1:CXSaggrXdbHK9CF+8ywj8Amf7PBRmPCOJugH954Nnlo=
 github.com/spf13/cobra v1.9.1/go.mod h1:nDyEzZ8ogv936Cinf6g1RU9MRY64Ir93oCnqb9wxYW0=
 github.com/spf13/pflag v1.0.6 h1:jFzHGLGAlb3ruxLB8MhbI6A8+AQX/2eW4qeyNZXNp2o=
@@ -53,8 +57,8 @@ github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e h1:JVG44RsyaB9T2KIHavM
 github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e/go.mod h1:RbqR21r5mrJuqunuUZ/Dhy/avygyECGrLceyNeo4LiM=
 golang.org/x/exp v0.0.0-20220909182711-5c715a9e8561 h1:MDc5xs78ZrZr3HMQugiXOAkSZtfTpbJLDr/lwfgO53E=
 golang.org/x/exp v0.0.0-20220909182711-5c715a9e8561/go.mod h1:cyybsKvd6eL0RnXn6p/Grxp8F5bW7iYuBgsNCOHpMYE=
-golang.org/x/sync v0.11.0 h1:GGz8+XQP4FvTTrjZPzNKTMFtSXH80RAzG+5ghFPgK9w=
-golang.org/x/sync v0.11.0/go.mod h1:Czt+wKu1gCyEFDUtn0jG5QVvpJ6rzVqr5aXyt9drQfk=
+golang.org/x/sync v0.16.0 h1:ycBJEhp9p4vXvUZNszeOq0kGTPghopOL8q0fq3vstxw=
+golang.org/x/sync v0.16.0/go.mod h1:1dzgHSNfp02xaA81J2MS99Qcpr2w7fw1gpm99rleRqA=
 golang.org/x/sys v0.0.0-20210809222454-d867a43fc93e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.32.0 h1:s77OFDvIQeibCmezSnk/q6iAfkdiQaJi4VzroCFrN20=

--- a/render/bindings.go
+++ b/render/bindings.go
@@ -18,6 +18,7 @@ const (
 	enter            bindingKey = "enter"
 	editFile         bindingKey = "e"
 	quickSearch      bindingKey = "/"
+	globalSearch     bindingKey = "ctrl+p"
 	toggleChart      bindingKey = "ctrl+w"
 	toggleLangFilter bindingKey = "tab"
 	toggleLangSelect bindingKey = "ctrl+l"
@@ -131,6 +132,13 @@ var dirsKeyMap = [][]key.Binding{
 			key.WithHelp(
 				bindKeyStyle.Render(quickSearch.String()),
 				helpDescStyle.Render(" - Quick search"),
+			),
+		),
+		key.NewBinding(
+			key.WithKeys(globalSearch.String()),
+			key.WithHelp(
+				bindKeyStyle.Render(globalSearch.String()),
+				helpDescStyle.Render(" - Global search"),
 			),
 		),
 		key.NewBinding(

--- a/render/dir_model.go
+++ b/render/dir_model.go
@@ -5,18 +5,23 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"slices"
 	"sort"
 	"strconv"
 	"strings"
 	"time"
+	"unicode/utf8"
 
 	"github.com/zdyxry/tokui/filter"
+	"github.com/zdyxry/tokui/search"
 	"github.com/zdyxry/tokui/structure"
 
 	"github.com/charmbracelet/bubbles/table"
+	"github.com/charmbracelet/bubbles/textinput"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
+	"github.com/charmbracelet/x/ansi"
 	"github.com/mattn/go-runewidth"
 )
 
@@ -27,6 +32,7 @@ const (
 	READY   Mode = "READY"
 	INPUT   Mode = "INPUT"
 	PREVIEW Mode = "PREVIEW"
+	SEARCH  Mode = "SEARCH"
 )
 
 const (
@@ -85,6 +91,14 @@ type DirModel struct {
 	treemapSelected int
 	treemapOffsetY  int // screen Y where the treemap canvas starts
 
+	// Global search state
+	searchIndex         *search.Index
+	searchInput         textinput.Model
+	searchMatches       []search.Match
+	searchCursor        int
+	searchOffset        int
+	pendingSearchTarget *structure.Entry // for treemap mode selection after render
+
 	// Mouse support
 	overlayBounds overlayBounds
 	lastClick     mouseClick
@@ -98,7 +112,7 @@ type mouseClick struct {
 
 // overlayBounds tracks the screen position of the currently rendered overlay.
 type overlayBounds struct {
-	kind      string // "preview", "chart" or "langselect"
+	kind      string // "preview", "chart", "langselect" or "search"
 	x, y      int    // top-left corner
 	w, h      int    // width and height
 	langStart int    // first visible language index (for langselect)
@@ -132,6 +146,8 @@ func NewDirModel(nav *Navigation, tokeiVersion string, treeMode, treemapMode boo
 		filter.NewNameFilter("Filter by name..."),
 	}
 
+	searchInput := newSearchInput()
+
 	dm := &DirModel{
 		columns:       columns,
 		filters:       filter.NewFiltersList(defaultFilters...),
@@ -146,9 +162,21 @@ func NewDirModel(nav *Navigation, tokeiVersion string, treeMode, treemapMode boo
 		treeMode:      treeMode,
 		treemapMode:   treemapMode,
 		sortState:     SortState{Key: SortByTotal, Desc: true},
+		searchInput:   searchInput,
 	}
 
 	return dm
+}
+
+// newSearchInput creates a styled text input for the global search overlay.
+func newSearchInput() textinput.Model {
+	ti := textinput.New()
+	ti.Placeholder = "Search files and directories..."
+	ti.Focus()
+	ti.Prompt = "  "
+	ti.PromptStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("#ebbd34"))
+	ti.TextStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("#ebbd34"))
+	return ti
 }
 
 func (dm *DirModel) ToggleTreeMode() {
@@ -206,6 +234,7 @@ func (dm *DirModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		dm.mode = READY
 		dm.updateLanguages()
 		dm.updateTableData(msg.ResetCursor)
+		dm.searchIndex = search.BuildIndex(dm.nav.tree.Root())
 
 	case CycleLangFilter:
 		if len(dm.languages) > 0 {
@@ -232,6 +261,9 @@ func (dm *DirModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case tea.WindowSizeMsg:
 		dm.updateSize(msg.Width, msg.Height)
 		dm.filters.Update(msg)
+		var searchCmd tea.Cmd
+		dm.searchInput, searchCmd = dm.searchInput.Update(msg)
+		_ = searchCmd
 
 	case tea.KeyMsg:
 		if dm.err != nil {
@@ -417,6 +449,10 @@ func (dm *DirModel) View() string {
 		return OverlayCenter(dm.width, dm.height, bg, errorView)
 	}
 
+	if dm.mode == SEARCH {
+		return dm.viewSearchOverlay(bg)
+	}
+
 	return bg
 }
 
@@ -478,6 +514,12 @@ func (dm *DirModel) handleKeyBindings(msg tea.KeyMsg) (tea.Cmd, bool) {
 		return nil, true
 	}
 
+	// Global search (Ctrl+P): activate fuzzy project-wide search
+	if bk == globalSearch {
+		dm.openGlobalSearch()
+		return nil, true
+	}
+
 	// If in input mode, handle special keys
 	if dm.mode == INPUT {
 		// Escape key exits input mode
@@ -498,6 +540,56 @@ func (dm *DirModel) handleKeyBindings(msg tea.KeyMsg) (tea.Cmd, bool) {
 		dm.filters.Update(msg)
 		dm.updateTableData()
 		return nil, true
+	}
+
+	// Global search mode.
+	if dm.mode == SEARCH {
+		switch bk {
+		case escape:
+			dm.closeGlobalSearch()
+			return nil, true
+		case enter:
+			// Handled by ViewModel to perform navigation.
+			return nil, false
+		case "up", "k":
+			if dm.searchCursor > 0 {
+				dm.searchCursor--
+			}
+			return nil, true
+		case "down", "j":
+			if dm.searchCursor < len(dm.searchMatches)-1 {
+				dm.searchCursor++
+			}
+			return nil, true
+		case "pgup":
+			dm.searchCursor -= 10
+			if dm.searchCursor < 0 {
+				dm.searchCursor = 0
+			}
+			return nil, true
+		case "pgdown":
+			if len(dm.searchMatches) > 0 {
+				dm.searchCursor += 10
+				if dm.searchCursor >= len(dm.searchMatches) {
+					dm.searchCursor = len(dm.searchMatches) - 1
+				}
+			}
+			return nil, true
+		case "home", "g":
+			dm.searchCursor = 0
+			return nil, true
+		case "end", "G":
+			if len(dm.searchMatches) > 0 {
+				dm.searchCursor = len(dm.searchMatches) - 1
+			}
+			return nil, true
+		}
+
+		// Pass other keys to the search input for typing.
+		var searchCmd tea.Cmd
+		dm.searchInput, searchCmd = dm.searchInput.Update(msg)
+		dm.updateSearchQuery()
+		return searchCmd, true
 	}
 
 	// Treemap-specific navigation and toggling.
@@ -1184,6 +1276,19 @@ func (dm *DirModel) viewTreemap(availableHeight int) string {
 
 	view, blocks := Treemap(w, h, children, getSize, dm.treemapSelected)
 	dm.treemapBlocks = blocks
+
+	// If a global search result was just applied in treemap mode, select the
+	// corresponding block now that the blocks have been laid out.
+	if dm.pendingSearchTarget != nil {
+		idx := dm.findTreemapBlockIndex(dm.pendingSearchTarget)
+		if idx >= 0 {
+			dm.treemapSelected = idx
+			view, blocks = Treemap(w, h, children, getSize, dm.treemapSelected)
+			dm.treemapBlocks = blocks
+		}
+		dm.pendingSearchTarget = nil
+	}
+
 	if len(blocks) > 0 && dm.treemapSelected >= len(blocks) {
 		dm.treemapSelected = len(blocks) - 1
 		view, _ = Treemap(w, h, children, getSize, dm.treemapSelected)
@@ -1272,6 +1377,360 @@ func (dm *DirModel) ExitSearchMode() {
 		}
 		dm.updateTableData()
 	}
+}
+
+// Global search helpers -----------------------------------------------------
+
+func (dm *DirModel) openGlobalSearch() {
+	if dm.mode == SEARCH {
+		return
+	}
+	// Close other overlays/state before entering global search.
+	dm.showCart = false
+	if dm.mode == PREVIEW {
+		dm.filePreview = nil
+	}
+	dm.mode = SEARCH
+	dm.searchInput.Reset()
+	dm.searchInput.Focus()
+	dm.searchCursor = 0
+	dm.searchOffset = 0
+	dm.searchMatches = nil
+	dm.updateSearchQuery()
+}
+
+func (dm *DirModel) closeGlobalSearch() {
+	if dm.mode != SEARCH {
+		return
+	}
+	dm.mode = READY
+	dm.searchInput.Blur()
+	dm.searchMatches = nil
+	dm.searchCursor = 0
+	dm.searchOffset = 0
+	dm.pendingSearchTarget = nil
+}
+
+func (dm *DirModel) updateSearchQuery() {
+	if dm.searchIndex == nil {
+		dm.searchMatches = nil
+		return
+	}
+	query := dm.searchInput.Value()
+	dm.searchMatches = dm.searchIndex.Find(query)
+	dm.searchCursor = 0
+	dm.searchOffset = 0
+}
+
+// SelectedSearchMatch returns the currently highlighted search match, if any.
+func (dm *DirModel) SelectedSearchMatch() *search.Match {
+	if dm.mode != SEARCH || dm.searchCursor < 0 || dm.searchCursor >= len(dm.searchMatches) {
+		return nil
+	}
+	return &dm.searchMatches[dm.searchCursor]
+}
+
+// applySearchResult navigates to the selected search result and positions the
+// cursor accordingly. It closes the global search overlay.
+func (dm *DirModel) applySearchResult() {
+	match := dm.SelectedSearchMatch()
+	if match == nil {
+		dm.closeGlobalSearch()
+		return
+	}
+
+	target := match.Item.Entry
+	if target == nil {
+		dm.closeGlobalSearch()
+		return
+	}
+
+	wasTreeMode := dm.treeMode
+	wasTreemapMode := dm.treemapMode
+
+	if wasTreeMode {
+		// Tree mode should keep the project root as the tree root. Expand the
+		// path from the root to the target and select the corresponding row so
+		// the full project tree stays visible.
+		dm.nav.entry = dm.nav.tree.Root()
+		dm.nav.entryStack = &entryStack{}
+		dm.nav.cursor = 0
+		dm.expandPathFromRootTo(target)
+
+		dm.closeGlobalSearch()
+		dm.updateTableData(true)
+
+		idx := dm.findChildIndex(target)
+		if idx >= 0 && idx < len(dm.tableEntries) {
+			dm.nav.cursor = idx
+			dm.dirsTable.SetCursor(idx)
+		}
+		return
+	}
+
+	// NavigateToPath returns the target entry and leaves the navigation at the parent directory.
+	found := dm.nav.NavigateToPath(match.Item.Path)
+	if found == nil {
+		dm.closeGlobalSearch()
+		return
+	}
+
+	var childToSelect *structure.Entry
+	if found.IsDir {
+		if wasTreemapMode {
+			// For treemap, enter the directory so its children fill the canvas.
+			dm.nav.Down(found.Name(), 0, 0)
+		} else {
+			// For navigation mode, enter the directory.
+			dm.nav.Down(found.Name(), 0, 0)
+		}
+	} else {
+		// Navigation is already at the parent directory; remember the child to select.
+		childToSelect = found
+	}
+
+	dm.closeGlobalSearch()
+	dm.updateTableData(true)
+
+	if wasTreemapMode {
+		// Defer block selection until viewTreemap has laid out the blocks.
+		dm.pendingSearchTarget = found
+	} else {
+		// After the table has been rebuilt, position the cursor on the target row.
+		if childToSelect != nil {
+			idx := dm.findChildIndex(childToSelect)
+			if idx >= 0 && idx < len(dm.tableEntries) {
+				dm.nav.cursor = idx
+				dm.dirsTable.SetCursor(idx)
+			}
+		}
+	}
+}
+
+// expandPathFromRootTo expands every directory on the path from the project
+// root down to the given target entry so that the target row becomes visible
+// in tree mode. The navigation entry is left at the project root.
+func (dm *DirModel) expandPathFromRootTo(target *structure.Entry) {
+	root := dm.nav.tree.Root()
+	if root == nil || target == nil {
+		return
+	}
+	root.Expanded = true
+	if root == target {
+		return
+	}
+
+	relPath, err := filepath.Rel(root.Path, target.Path)
+	if err != nil {
+		return
+	}
+	relPath = filepath.ToSlash(relPath)
+	if relPath == "" || relPath == "." {
+		return
+	}
+
+	parts := strings.Split(relPath, "/")
+	current := root
+	for _, part := range parts[:len(parts)-1] {
+		if part == "" {
+			continue
+		}
+		child := current.GetChild(part)
+		if child == nil || !child.IsDir {
+			return
+		}
+		child.Expanded = true
+		current = child
+	}
+	if target.IsDir {
+		target.Expanded = true
+	}
+}
+
+// findTreemapBlockIndex returns the index of the given entry in the current
+// treemap block list. It returns -1 if not found.
+func (dm *DirModel) findTreemapBlockIndex(target *structure.Entry) int {
+	if target == nil {
+		return -1
+	}
+	for i, b := range dm.treemapBlocks {
+		if b.entry == target {
+			return i
+		}
+	}
+	return -1
+}
+
+// findChildIndex returns the table index of the given entry within the current
+// directory's visible children. Returns -1 if not found.
+func (dm *DirModel) findChildIndex(target *structure.Entry) int {
+	if target == nil {
+		return -1
+	}
+	for i, te := range dm.tableEntries {
+		if te.entry == target {
+			return i
+		}
+	}
+	return -1
+}
+
+func (dm *DirModel) viewSearchOverlay(bg string) string {
+	if dm.width < 20 || dm.height < 10 {
+		return bg
+	}
+
+	// Box dimensions include border and padding. Content fits inside with a
+	// 2-cell horizontal and vertical margin reserved for border + padding.
+	boxWidth := min(dm.width-4, 100)
+	boxHeight := min(dm.height-4, 30)
+	if boxWidth < 20 {
+		boxWidth = min(dm.width, 20)
+	}
+	if boxHeight < 8 {
+		boxHeight = min(dm.height, 8)
+	}
+
+	// Inner width is the visible content area inside border + padding.
+	innerWidth := boxWidth - 4
+
+	// Size the text input so prompt + value fits within the inner width.
+	promptWidth := lipgloss.Width(dm.searchInput.Prompt)
+	dm.searchInput.Width = max(1, innerWidth-promptWidth)
+	inputView := dm.searchInput.View()
+
+	// Content lines: title(1) + description(1) + input(1) + results + status(1).
+	// Box height = content lines + padding(2) + border(2) => results = boxHeight - 8.
+	resultHeight := boxHeight - 8
+	if resultHeight < 1 {
+		resultHeight = 1
+	}
+
+	var resultLines []string
+	if len(dm.searchMatches) == 0 {
+		if dm.searchInput.Value() == "" {
+			resultLines = append(resultLines, lipgloss.NewStyle().Faint(true).Render("Type to search files and directories"))
+		} else {
+			resultLines = append(resultLines, lipgloss.NewStyle().Faint(true).Render("No matches"))
+		}
+	} else {
+		// Keep the cursor visible.
+		if dm.searchCursor < dm.searchOffset {
+			dm.searchOffset = dm.searchCursor
+		}
+		if dm.searchCursor >= dm.searchOffset+resultHeight {
+			dm.searchOffset = dm.searchCursor - resultHeight + 1
+		}
+		if dm.searchOffset < 0 {
+			dm.searchOffset = 0
+		}
+
+		end := dm.searchOffset + resultHeight
+		if end > len(dm.searchMatches) {
+			end = len(dm.searchMatches)
+		}
+
+		for i := dm.searchOffset; i < end; i++ {
+			match := dm.searchMatches[i]
+			line := dm.renderSearchResult(match, i == dm.searchCursor, innerWidth)
+			resultLines = append(resultLines, line)
+		}
+	}
+
+	// Pad result lines to keep the box height stable.
+	for len(resultLines) < resultHeight {
+		resultLines = append(resultLines, "")
+	}
+
+	status := fmt.Sprintf("%d/%d", dm.searchCursor+1, len(dm.searchMatches))
+	if len(dm.searchMatches) == 0 {
+		status = "0/0"
+	}
+
+	titleStyle := lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("#3a86ff"))
+	boxStyle := lipgloss.NewStyle().
+		BorderStyle(lipgloss.RoundedBorder()).
+		BorderForeground(lipgloss.Color("240")).
+		Padding(0, 1).
+		Width(boxWidth).
+		Height(boxHeight)
+
+	content := []string{
+		titleStyle.Render("Global Search"),
+		lipgloss.NewStyle().Faint(true).Render("Ctrl+P: open • Enter: jump • Esc: close"),
+		inputView,
+		lipgloss.JoinVertical(lipgloss.Top, resultLines...),
+		lipgloss.NewStyle().Faint(true).Align(lipgloss.Right).Render(status),
+	}
+
+	box := boxStyle.Render(lipgloss.JoinVertical(lipgloss.Top, content...))
+	dm.overlayBounds = overlayBounds{
+		kind: "search",
+		x:    dm.width/2 - lipgloss.Width(box)/2,
+		y:    dm.height/2 - lipgloss.Height(box)/2,
+		w:    lipgloss.Width(box),
+		h:    lipgloss.Height(box),
+	}
+
+	return OverlayCenter(dm.width, dm.height, bg, box)
+}
+
+// byteIndexesToRuneIndexes converts byte offsets into rune offsets for the
+// given string. The fuzzy package returns byte indexes, while lipgloss.StyleRunes
+// expects rune indexes.
+func byteIndexesToRuneIndexes(s string, byteIdxs []int) []int {
+	runeIdxs := make([]int, len(byteIdxs))
+	for i, bi := range byteIdxs {
+		if bi < 0 || bi > len(s) {
+			continue
+		}
+		runeIdxs[i] = utf8.RuneCountInString(s[:bi])
+	}
+	return runeIdxs
+}
+
+func (dm *DirModel) renderSearchResult(match search.Match, selected bool, maxWidth int) string {
+	path := match.Item.Path
+	if path == "." {
+		path = dm.nav.tree.Root().Path
+		if path == "" || path == "." {
+			path = "(root)"
+		}
+	}
+
+	icon := EntryIcon(match.Item.Entry)
+	prefix := icon + "  "
+	prefixWidth := lipgloss.Width(prefix)
+	available := maxWidth - prefixWidth
+	if available < 5 {
+		available = 5
+	}
+
+	highlightStyle := lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("#fb5607"))
+	plainStyle := lipgloss.NewStyle()
+	selectedStyle := lipgloss.NewStyle().Background(lipgloss.Color("240"))
+
+	// The fuzzy package returns byte indexes; StyleRunes expects rune indexes.
+	runeIndexes := byteIndexesToRuneIndexes(path, match.MatchedIndexes)
+	renderedPath := lipgloss.StyleRunes(path, runeIndexes, highlightStyle, plainStyle)
+
+	// Truncate the highlighted path if it exceeds the available width.
+	if lipgloss.Width(renderedPath) > available {
+		renderedPath = ansi.Truncate(renderedPath, available-1, "…")
+	}
+
+	line := prefix + renderedPath
+
+	if selected {
+		// Pad the line to fill the inner width so the selection background is consistent.
+		pad := maxWidth - lipgloss.Width(line)
+		if pad > 0 {
+			line += strings.Repeat(" ", pad)
+		}
+		line = selectedStyle.Render(line)
+	}
+
+	return ansi.Truncate(line, maxWidth, "")
 }
 
 // ShowFilePreview creates and shows a file preview

--- a/render/dir_model.go
+++ b/render/dir_model.go
@@ -263,7 +263,7 @@ func (dm *DirModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		dm.filters.Update(msg)
 		var searchCmd tea.Cmd
 		dm.searchInput, searchCmd = dm.searchInput.Update(msg)
-		_ = searchCmd
+		cmd = searchCmd
 
 	case tea.KeyMsg:
 		if dm.err != nil {

--- a/render/dir_model_test.go
+++ b/render/dir_model_test.go
@@ -64,13 +64,12 @@ func newTestDirModel() *DirModel {
 
 	root.AggregateStats()
 
-	return &DirModel{
-		nav:           &Navigation{entry: root},
-		languages:     []string{"Go", "Python"},
-		langFilterIdx: -1,
-		selectedLangs: make(map[string]bool),
-		sortState:     SortState{Key: SortByTotal, Desc: true},
-	}
+	dm := NewDirModel(NewCodeNavigation(structure.NewTree(root)), "", false, false)
+	dm.languages = []string{"Go", "Python"}
+	dm.langFilterIdx = -1
+	dm.selectedLangs = make(map[string]bool)
+	dm.sortState = SortState{Key: SortByTotal, Desc: true}
+	return dm
 }
 
 func TestDirModelComparableStats(t *testing.T) {
@@ -210,6 +209,278 @@ func TestDirModelToggleSortOrder(t *testing.T) {
 	}
 }
 
+func TestDirModelGlobalSearchOpenClose(t *testing.T) {
+	dm := newTestDirModel()
+	dm.Update(ScanFinished{})
+
+	dm.openGlobalSearch()
+	if dm.mode != SEARCH {
+		t.Fatalf("expected SEARCH mode, got %v", dm.mode)
+	}
+	if dm.searchIndex == nil {
+		t.Fatal("expected search index to be built")
+	}
+
+	dm.closeGlobalSearch()
+	if dm.mode != READY {
+		t.Fatalf("expected READY mode after close, got %v", dm.mode)
+	}
+}
+
+func TestDirModelGlobalSearchFindsFile(t *testing.T) {
+	dm := newTestDirModel()
+	dm.Update(ScanFinished{})
+	dm.openGlobalSearch()
+
+	dm.searchInput.SetValue("b.py")
+	dm.updateSearchQuery()
+
+	if len(dm.searchMatches) == 0 {
+		t.Fatalf("expected matches for 'b.py', got none")
+	}
+	if dm.searchMatches[0].Item.Path != "b.py" {
+		t.Errorf("expected first match to be b.py, got %q", dm.searchMatches[0].Item.Path)
+	}
+}
+
+func TestDirModelApplySearchResultDirectory(t *testing.T) {
+	dm := newTestDirModel()
+	dm.Update(ScanFinished{})
+	dm.openGlobalSearch()
+
+	// "root" is the top-level directory; selecting it should keep us at root.
+	dm.searchInput.SetValue("root")
+	dm.updateSearchQuery()
+	dm.applySearchResult()
+
+	if dm.mode != READY {
+		t.Fatalf("expected READY mode after apply, got %v", dm.mode)
+	}
+	if dm.nav.Entry().Path != "root" {
+		t.Errorf("expected nav at root, got %q", dm.nav.Entry().Path)
+	}
+}
+
+func TestDirModelApplySearchResultFile(t *testing.T) {
+	dm := newTestDirModel()
+	dm.Update(ScanFinished{})
+	dm.openGlobalSearch()
+
+	dm.searchInput.SetValue("b.py")
+	dm.updateSearchQuery()
+	dm.applySearchResult()
+
+	if dm.mode != READY {
+		t.Fatalf("expected READY mode after apply, got %v", dm.mode)
+	}
+	if dm.nav.Entry().Path != "root" {
+		t.Errorf("expected nav at parent directory root, got %q", dm.nav.Entry().Path)
+	}
+
+	idx := dm.findChildIndex(dm.nav.Entry().GetChild("b.py"))
+	if idx < 0 {
+		t.Fatal("expected b.py to be visible in the table")
+	}
+	if dm.dirsTable.Cursor() != idx {
+		t.Errorf("expected cursor at b.py index %d, got %d", idx, dm.dirsTable.Cursor())
+	}
+}
+
+func newTestNestedDirModel() *DirModel {
+	root := structure.NewDirEntry("root")
+
+	root.AddChild(structure.NewFileEntry("root/a.go", map[string]structure.CodeStats{
+		"Go": {Code: 20, Comments: 5, Blanks: 5},
+	}))
+
+	subdir := structure.NewDirEntry("root/subdir")
+	root.AddChild(subdir)
+	subdir.AddChild(structure.NewFileEntry("root/subdir/b.py", map[string]structure.CodeStats{
+		"Python": {Code: 10, Comments: 2, Blanks: 3},
+	}))
+
+	root.AggregateStats()
+
+	dm := NewDirModel(NewCodeNavigation(structure.NewTree(root)), "", false, false)
+	dm.languages = []string{"Go", "Python"}
+	dm.langFilterIdx = -1
+	dm.selectedLangs = make(map[string]bool)
+	dm.sortState = SortState{Key: SortByTotal, Desc: true}
+	return dm
+}
+
+func TestDirModelApplySearchResultFromTreeMode(t *testing.T) {
+	dm := newTestNestedDirModel()
+	dm.Update(ScanFinished{})
+	dm.treeMode = true
+	dm.openGlobalSearch()
+
+	dm.searchInput.SetValue("b.py")
+	dm.updateSearchQuery()
+	dm.applySearchResult()
+
+	if !dm.treeMode {
+		t.Error("expected tree mode to remain active after global search jump")
+	}
+	if dm.treemapMode {
+		t.Error("expected treemap mode to remain disabled after global search jump")
+	}
+	if dm.nav.Entry().Path != "root" {
+		t.Errorf("expected tree root to stay at project root, got %q", dm.nav.Entry().Path)
+	}
+	subdir := dm.nav.Entry().GetChild("subdir")
+	if subdir == nil {
+		t.Fatal("expected subdir to be visible under root")
+	}
+	if !subdir.Expanded {
+		t.Error("expected subdir to be expanded so the target file is visible")
+	}
+
+	target := subdir.GetChild("b.py")
+	if target == nil {
+		t.Fatal("expected b.py to be visible under subdir")
+	}
+	idx := dm.findChildIndex(target)
+	if idx < 0 {
+		t.Fatal("expected b.py to be visible in the tree table")
+	}
+	if dm.dirsTable.Cursor() != idx {
+		t.Errorf("expected cursor on b.py index %d, got %d", idx, dm.dirsTable.Cursor())
+	}
+}
+
+func TestDirModelApplySearchResultFromTreeModeDirectory(t *testing.T) {
+	dm := newTestNestedDirModel()
+	dm.Update(ScanFinished{})
+	dm.treeMode = true
+	dm.openGlobalSearch()
+
+	dm.searchInput.SetValue("subdir")
+	dm.updateSearchQuery()
+	dm.applySearchResult()
+
+	if !dm.treeMode {
+		t.Error("expected tree mode to remain active after global search jump")
+	}
+	if dm.nav.Entry().Path != "root" {
+		t.Errorf("expected nav at parent directory root, got %q", dm.nav.Entry().Path)
+	}
+	if !dm.nav.Entry().GetChild("subdir").Expanded {
+		t.Error("expected subdir to be expanded after searching for it in tree mode")
+	}
+
+	idx := dm.findChildIndex(dm.nav.Entry().GetChild("subdir"))
+	if idx < 0 {
+		t.Fatal("expected subdir to be visible after search jump")
+	}
+	if dm.dirsTable.Cursor() != idx {
+		t.Errorf("expected cursor on subdir index %d, got %d", idx, dm.dirsTable.Cursor())
+	}
+}
+
+func TestDirModelApplySearchResultFromTreemapMode(t *testing.T) {
+	dm := newTestNestedDirModel()
+	dm.Update(ScanFinished{})
+	dm.width = 80
+	dm.height = 24
+	dm.treemapMode = true
+	dm.openGlobalSearch()
+
+	dm.searchInput.SetValue("b.py")
+	dm.updateSearchQuery()
+	dm.applySearchResult()
+
+	if !dm.treemapMode {
+		t.Error("expected treemap mode to remain active after global search jump")
+	}
+	if dm.treeMode {
+		t.Error("expected tree mode to remain disabled after global search jump")
+	}
+	if dm.nav.Entry().Path != "root/subdir" {
+		t.Errorf("expected nav at parent directory root/subdir, got %q", dm.nav.Entry().Path)
+	}
+
+	_ = dm.View() // trigger treemap block layout
+
+	idx := dm.findTreemapBlockIndex(dm.nav.Entry().GetChild("b.py"))
+	if idx < 0 {
+		t.Fatalf("expected b.py to be visible in treemap blocks after search jump, got %d blocks", len(dm.treemapBlocks))
+	}
+	if dm.treemapSelected != idx {
+		t.Errorf("expected treemap selection on b.py index %d, got %d", idx, dm.treemapSelected)
+	}
+}
+
+func TestDirModelApplySearchResultFromTreemapModeDirectory(t *testing.T) {
+	dm := newTestNestedDirModel()
+	dm.Update(ScanFinished{})
+	dm.width = 80
+	dm.height = 24
+	dm.treemapMode = true
+	dm.openGlobalSearch()
+
+	dm.searchInput.SetValue("subdir")
+	dm.updateSearchQuery()
+	dm.applySearchResult()
+
+	if !dm.treemapMode {
+		t.Error("expected treemap mode to remain active after global search jump")
+	}
+	if dm.treeMode {
+		t.Error("expected tree mode to remain disabled after global search jump")
+	}
+	if dm.nav.Entry().Path != "root/subdir" {
+		t.Errorf("expected nav to enter subdir, got %q", dm.nav.Entry().Path)
+	}
+
+	_ = dm.View() // trigger treemap block layout
+
+	// After entering subdir, the treemap should show its children (b.py).
+	idx := dm.findTreemapBlockIndex(dm.nav.Entry().GetChild("b.py"))
+	if idx < 0 {
+		t.Fatalf("expected b.py to be visible in treemap blocks after jumping to subdir, got %d blocks", len(dm.treemapBlocks))
+	}
+}
+
+func TestViewModelGlobalSearchJumpsToFile(t *testing.T) {
+	dm := newTestDirModel()
+	dm.Update(ScanFinished{})
+	vm := NewViewModel(dm.nav, dm)
+
+	// Press Ctrl+P to open global search.
+	_, cmd := vm.Update(tea.KeyMsg{Type: tea.KeyCtrlP})
+	if cmd != nil {
+		t.Fatalf("expected Ctrl+P not to return a command, got %v", cmd)
+	}
+	if dm.mode != SEARCH {
+		t.Fatalf("expected SEARCH mode after Ctrl+P, got %v", dm.mode)
+	}
+
+	// Type the query and update the model directly (DirModel handles typing).
+	dm.searchInput.SetValue("b.py")
+	dm.updateSearchQuery()
+
+	// Press Enter to apply the search result.
+	_, cmd = vm.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	if cmd != nil {
+		t.Fatalf("expected Enter not to return a command, got %v", cmd)
+	}
+	if dm.mode != READY {
+		t.Fatalf("expected READY mode after applying search result, got %v", dm.mode)
+	}
+	if dm.nav.Entry().Path != "root" {
+		t.Errorf("expected navigation at root, got %q", dm.nav.Entry().Path)
+	}
+
+	idx := dm.findChildIndex(dm.nav.Entry().GetChild("b.py"))
+	if idx < 0 {
+		t.Fatal("expected b.py to be visible after search jump")
+	}
+	if dm.dirsTable.Cursor() != idx {
+		t.Errorf("expected cursor on b.py (index %d), got %d", idx, dm.dirsTable.Cursor())
+	}
+}
+
 func TestViewModelPreviewQClosesPreviewWithoutQuitting(t *testing.T) {
 	dm := newTestDirModel()
 	dm.mode = PREVIEW
@@ -283,5 +554,42 @@ func TestTreemapKeyboardStaysAtTopLevel(t *testing.T) {
 	dm.moveTreemapSelection(1)
 	if dm.treemapSelected != 3 {
 		t.Fatalf("expected selection from nested block to jump to top-level b (index 3), got %d", dm.treemapSelected)
+	}
+}
+
+func TestByteIndexesToRuneIndexes(t *testing.T) {
+	// "中" is 3 bytes; "a中b" has byte offsets 0,1,4,5 and rune offsets 0,1,2,3.
+	s := "a中b"
+	byteIdxs := []int{0, 1, 4, 5}
+	want := []int{0, 1, 2, 3}
+
+	got := byteIndexesToRuneIndexes(s, byteIdxs)
+	if len(got) != len(want) {
+		t.Fatalf("expected %v, got %v", want, got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("at index %d: expected %d, got %d", i, want[i], got[i])
+		}
+	}
+}
+
+func TestDirModelGlobalSearchPgDownNoMatches(t *testing.T) {
+	dm := newTestDirModel()
+	dm.Update(ScanFinished{})
+	dm.openGlobalSearch()
+
+	dm.searchInput.SetValue("nonexistent")
+	dm.updateSearchQuery()
+
+	if len(dm.searchMatches) != 0 {
+		t.Fatalf("expected no matches, got %d", len(dm.searchMatches))
+	}
+
+	msg := tea.KeyMsg{Type: tea.KeyPgDown}
+	dm.Update(msg)
+
+	if dm.searchCursor != 0 {
+		t.Errorf("expected cursor to stay at 0 with no matches, got %d", dm.searchCursor)
 	}
 }

--- a/render/navigation.go
+++ b/render/navigation.go
@@ -2,6 +2,7 @@ package render
 
 import (
 	"path/filepath"
+	"strings"
 
 	"github.com/zdyxry/tokui/structure"
 )
@@ -96,4 +97,44 @@ func (n *Navigation) AbsPathFromSelectedRow(selectedRow []string) string {
 	}
 
 	return ""
+}
+
+// NavigateToPath navigates to the parent directory of the given relative path
+// and returns the target entry (file or directory) located at that path.
+// The returned entry can be used by the caller to position the cursor.
+// If relPath is empty or ".", the root entry is returned.
+func (n *Navigation) NavigateToPath(relPath string) *structure.Entry {
+	n.entry = n.tree.Root()
+	n.entryStack = &entryStack{}
+	n.cursor = 0
+
+	relPath = strings.TrimSpace(relPath)
+	relPath = strings.TrimPrefix(relPath, "./")
+	if relPath == "" || relPath == "." {
+		return n.entry
+	}
+
+	localPath := filepath.FromSlash(relPath)
+	parts := strings.Split(localPath, string(filepath.Separator))
+
+	for i, part := range parts {
+		if part == "" {
+			continue
+		}
+
+		if i == len(parts)-1 {
+			// Last component can be a file or a directory.
+			return n.entry.GetChild(part)
+		}
+
+		child := n.entry.GetChild(part)
+		if child == nil || !child.IsDir {
+			return nil
+		}
+		n.entryStack.push(&stackItem{entry: n.entry, cursor: 0})
+		n.entry = child
+		n.cursor = 0
+	}
+
+	return n.entry
 }

--- a/render/render.go
+++ b/render/render.go
@@ -48,13 +48,14 @@ func (vm *ViewModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 		switch bk {
 		case quit:
-			if vm.dirModel.mode != PREVIEW && vm.dirModel.mode != INPUT {
+			if vm.dirModel.mode != PREVIEW && vm.dirModel.mode != INPUT && vm.dirModel.mode != SEARCH {
 				return vm, tea.Quit
 			}
 		case cancel:
 			return vm, tea.Quit
 		case enter:
-			if vm.dirModel.mode == INPUT {
+			switch vm.dirModel.mode {
+			case INPUT:
 				selectedEntry := vm.dirModel.SelectedEntry()
 				vm.dirModel.ExitSearchMode()
 				if selectedEntry != nil {
@@ -72,7 +73,9 @@ func (vm *ViewModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				} else if vm.dirModel.IsParentSelected() {
 					vm.levelUp()
 				}
-			} else {
+			case SEARCH:
+				vm.dirModel.applySearchResult()
+			default:
 				if vm.dirModel.IsParentSelected() {
 					vm.levelUp()
 				} else if vm.dirModel.treeMode {
@@ -85,7 +88,7 @@ func (vm *ViewModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 		case backspace:
 			// If DirModel is in input mode, don't handle top-level shortcuts
-			if vm.dirModel.mode == INPUT {
+			if vm.dirModel.mode == INPUT || vm.dirModel.mode == SEARCH {
 				break
 			}
 			vm.levelUp()

--- a/search/search.go
+++ b/search/search.go
@@ -53,18 +53,22 @@ func BuildIndex(root *structure.Entry) *Index {
 	idx := &Index{}
 	idx.items = make([]Item, 0, 1024)
 
-	rootPrefix := strings.TrimSuffix(filepath.ToSlash(root.Path), "/")
+	rootPath := filepath.Clean(filepath.FromSlash(root.Path))
 
 	var walk func(entry *structure.Entry)
 	walk = func(entry *structure.Entry) {
-		entryPath := filepath.ToSlash(entry.Path)
+		if entry == nil {
+			return
+		}
 
-		var relPath string
-		if entry == root {
-			relPath = "."
-		} else {
-			relPath = strings.TrimPrefix(entryPath, rootPrefix)
-			relPath = strings.TrimPrefix(relPath, "/")
+		relPath := "."
+		if entry != root {
+			entryPath := filepath.Clean(filepath.FromSlash(entry.Path))
+			r, err := filepath.Rel(rootPath, entryPath)
+			if err != nil {
+				r = entryPath
+			}
+			relPath = filepath.ToSlash(filepath.Clean(r))
 		}
 
 		idx.items = append(idx.items, Item{
@@ -74,6 +78,9 @@ func BuildIndex(root *structure.Entry) *Index {
 
 		if entry.IsDir {
 			for _, child := range entry.Child {
+				if child == nil {
+					continue
+				}
 				walk(child)
 			}
 		}

--- a/search/search.go
+++ b/search/search.go
@@ -1,0 +1,117 @@
+// Package search provides an in-memory fuzzy search index over a structure.Entry tree.
+package search
+
+import (
+	"path/filepath"
+	"strings"
+
+	"github.com/sahilm/fuzzy"
+	"github.com/zdyxry/tokui/structure"
+)
+
+// Item represents a single searchable file or directory.
+type Item struct {
+	Entry *structure.Entry
+	Path  string // path relative to the tree root, using '/' separators
+}
+
+// Match represents a single fuzzy match result.
+type Match struct {
+	Item           Item
+	Score          int
+	MatchedIndexes []int
+}
+
+// Index holds a flat list of all searchable entries in a project tree.
+type Index struct {
+	items []Item
+}
+
+// itemSource adapts []Item to fuzzy.Source.
+type itemSource struct {
+	items []Item
+}
+
+func (s itemSource) String(i int) string {
+	if i < 0 || i >= len(s.items) {
+		return ""
+	}
+	return s.items[i].Path
+}
+
+func (s itemSource) Len() int {
+	return len(s.items)
+}
+
+// BuildIndex recursively walks the entry tree and creates a searchable index.
+// The returned paths are relative to root.Path and always use '/' separators.
+func BuildIndex(root *structure.Entry) *Index {
+	if root == nil {
+		return &Index{}
+	}
+
+	idx := &Index{}
+	idx.items = make([]Item, 0, 1024)
+
+	rootPrefix := strings.TrimSuffix(filepath.ToSlash(root.Path), "/")
+
+	var walk func(entry *structure.Entry)
+	walk = func(entry *structure.Entry) {
+		entryPath := filepath.ToSlash(entry.Path)
+
+		var relPath string
+		if entry == root {
+			relPath = "."
+		} else {
+			relPath = strings.TrimPrefix(entryPath, rootPrefix)
+			relPath = strings.TrimPrefix(relPath, "/")
+		}
+
+		idx.items = append(idx.items, Item{
+			Entry: entry,
+			Path:  relPath,
+		})
+
+		if entry.IsDir {
+			for _, child := range entry.Child {
+				walk(child)
+			}
+		}
+	}
+
+	walk(root)
+	return idx
+}
+
+// Find performs a fuzzy search against the indexed paths.
+// Results are sorted from best to worst match.
+func (idx *Index) Find(query string) []Match {
+	if idx == nil || len(idx.items) == 0 {
+		return nil
+	}
+	query = strings.TrimSpace(query)
+	if query == "" {
+		return nil
+	}
+
+	src := itemSource{items: idx.items}
+	results := fuzzy.FindFrom(query, src)
+
+	matches := make([]Match, 0, len(results))
+	for _, r := range results {
+		matches = append(matches, Match{
+			Item:           idx.items[r.Index],
+			Score:          r.Score,
+			MatchedIndexes: r.MatchedIndexes,
+		})
+	}
+	return matches
+}
+
+// Items returns the total number of indexed items.
+func (idx *Index) Items() int {
+	if idx == nil {
+		return 0
+	}
+	return len(idx.items)
+}

--- a/search/search_test.go
+++ b/search/search_test.go
@@ -1,0 +1,122 @@
+package search
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/zdyxry/tokui/structure"
+)
+
+func buildTestTree() *structure.Entry {
+	root := structure.NewDirEntry("/project")
+
+	cmd := structure.NewDirEntry(filepath.Join("/project", "cmd"))
+	root.AddChild(cmd)
+	cmd.AddChild(structure.NewFileEntry(filepath.Join("/project", "cmd", "app.go"), map[string]structure.CodeStats{
+		"Go": {Code: 10, Comments: 2, Blanks: 1},
+	}))
+	cmd.AddChild(structure.NewFileEntry(filepath.Join("/project", "cmd", "error.go"), map[string]structure.CodeStats{
+		"Go": {Code: 5, Comments: 1, Blanks: 1},
+	}))
+
+	render := structure.NewDirEntry(filepath.Join("/project", "render"))
+	root.AddChild(render)
+	render.AddChild(structure.NewFileEntry(filepath.Join("/project", "render", "dir_model.go"), map[string]structure.CodeStats{
+		"Go": {Code: 20, Comments: 5, Blanks: 3},
+	}))
+
+	return root
+}
+
+func TestBuildIndex(t *testing.T) {
+	root := buildTestTree()
+	idx := BuildIndex(root)
+
+	if idx.Items() == 0 {
+		t.Fatal("expected non-empty index")
+	}
+
+	paths := make(map[string]bool)
+	for _, item := range idx.items {
+		paths[item.Path] = true
+	}
+
+	expected := []string{".", "cmd", "cmd/app.go", "cmd/error.go", "render", "render/dir_model.go"}
+	for _, p := range expected {
+		if !paths[p] {
+			t.Errorf("expected path %q in index", p)
+		}
+	}
+}
+
+func TestFind_Exact(t *testing.T) {
+	root := buildTestTree()
+	idx := BuildIndex(root)
+
+	matches := idx.Find("dir_model.go")
+	if len(matches) == 0 {
+		t.Fatal("expected at least one match")
+	}
+
+	if matches[0].Item.Path != "render/dir_model.go" {
+		t.Errorf("expected first match to be render/dir_model.go, got %q", matches[0].Item.Path)
+	}
+}
+
+func TestFind_Fuzzy(t *testing.T) {
+	root := buildTestTree()
+	idx := BuildIndex(root)
+
+	matches := idx.Find("cmdapp")
+	found := false
+	for _, m := range matches {
+		if m.Item.Path == "cmd/app.go" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected fuzzy query 'cmdapp' to match cmd/app.go, got %v", matches)
+	}
+}
+
+func TestFind_Directory(t *testing.T) {
+	root := buildTestTree()
+	idx := BuildIndex(root)
+
+	matches := idx.Find("render")
+	found := false
+	for _, m := range matches {
+		if m.Item.Path == "render" && m.Item.Entry.IsDir {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected query 'render' to match render directory, got %v", matches)
+	}
+}
+
+func TestFind_EmptyQuery(t *testing.T) {
+	root := buildTestTree()
+	idx := BuildIndex(root)
+
+	matches := idx.Find("")
+	if len(matches) != 0 {
+		t.Errorf("expected no matches for empty query, got %d", len(matches))
+	}
+}
+
+func TestFind_HighlightIndexes(t *testing.T) {
+	root := buildTestTree()
+	idx := BuildIndex(root)
+
+	matches := idx.Find("app")
+	if len(matches) == 0 {
+		t.Fatal("expected at least one match")
+	}
+
+	if len(matches[0].MatchedIndexes) == 0 {
+		t.Error("expected non-empty matched indexes")
+	}
+}


### PR DESCRIPTION
- Add search package using sahilm/fuzzy for project-wide file/dir search
- Add Ctrl+P keybinding and SEARCH overlay UI
- Support jumping to results in nav/tree/treemap modes
- Fix byte-to-rune index conversion for non-ASCII path highlighting
- Fix cursor bounds and Windows path handling
- Update README keybindings