### PR TITLE
feat(cli): add --version/-v flag to report tokui version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@
 BINARY_DIR=./bin
 BINARY_NAME=tokui
 TOKEI_VERSION?=14.0.0
+VERSION?=$(shell git describe --tags --always --dirty 2>/dev/null || echo dev)
 
 help: ## Show this help
 	@egrep '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-20s\033[0m %s\n", $$1, $$2}'
@@ -27,4 +28,4 @@ ensure-tokei-binaries: ## Ensure tokei binaries are present (fetch if missing, b
 	fi
 
 build: ensure-tokei-binaries ## Produce a binary
-	go build -ldflags "-s -w" -o ${BINARY_DIR}/${BINARY_NAME}
+	go build -ldflags "-s -w -X main.version=$(VERSION)" -o ${BINARY_DIR}/${BINARY_NAME}

--- a/cmd/app.go
+++ b/cmd/app.go
@@ -84,7 +84,11 @@ func init() {
 	appCmd.MarkFlagsMutuallyExclusive("tree", "treemap")
 }
 
-func Execute() {
+// Execute runs the root command. version is the version string to report via
+// the --version/-v flag; it is resolved against Go build info when it is empty
+// or the "dev" placeholder.
+func Execute(version string) {
+	appCmd.Version = resolveVersion(version)
 	if err := appCmd.Execute(); err != nil {
 		var cliErr *CLIError
 		if errors.As(err, &cliErr) {
@@ -95,6 +99,46 @@ func Execute() {
 		os.Exit(1)
 	}
 }
+
+// resolveVersion returns the version to report. It prefers an explicit,
+// build-injected version and otherwise falls back to Go module build info so
+// that binaries produced by `go install ...@version` still report something
+// useful instead of a bare "dev".
+func resolveVersion(version string) string {
+	if version != "" && version != "dev" {
+		return version
+	}
+
+	info, ok := debug.ReadBuildInfo()
+	if !ok {
+		return "dev"
+	}
+
+	if v := info.Main.Version; v != "" && v != "(devel)" {
+		return v
+	}
+
+	var revision, suffix string
+	for _, setting := range info.Settings {
+		switch setting.Key {
+		case "vcs.revision":
+			revision = setting.Value
+		case "vcs.modified":
+			if setting.Value == "true" {
+				suffix = "-dirty"
+			}
+		}
+	}
+	if revision != "" {
+		if len(revision) > 12 {
+			revision = revision[:12]
+		}
+		return "dev+" + revision + suffix
+	}
+
+	return "dev"
+}
+
 
 func runApp(cmd *cobra.Command, args []string) error {
 	defer func() {

--- a/main.go
+++ b/main.go
@@ -4,6 +4,11 @@ import (
 	"github.com/zdyxry/tokui/cmd"
 )
 
+// version is the tokui version string. It defaults to "dev" for local builds
+// and is overridden at release time via -ldflags "-X main.version=<tag>"
+// (goreleaser injects it into main.version by default).
+var version = "dev"
+
 func main() {
-	cmd.Execute()
+	cmd.Execute(version)
 }


### PR DESCRIPTION
## What

tokui had no way to report its own version — no `version` subcommand and no `--version` flag. This adds one.

## Changes

- **`cmd/app.go`**: `Execute` now takes a `version string` and sets `appCmd.Version`. cobra automatically exposes `--version` once `Version` is set; a `-v` shorthand is registered manually (tokui has no verbose flag, so `-v` is free). Adds `resolveVersion`, which prefers the build-injected version and otherwise falls back to Go module build info, so `go install ...@version` binaries still report a real version instead of a bare `dev`.
- **`main.go`**: adds `var version = "dev"` passed into `cmd.Execute`. This matches goreleaser's default injection point (`-X main.version`), so release builds pick up the tag automatically.
- **`Makefile`**: the `build` target now stamps `-X main.version=$(VERSION)`, with `VERSION` defaulting to `git describe --tags --always --dirty`.

## Why flag instead of subcommand

tokui is a single-command tool (its positional arg is a directory). A `version` subcommand would sit awkwardly next to `tokui [directory]`, so `--version`/`-v` is the cleaner fit and the common cobra convention.

## Verification

```
$ tokui --version   # tokui version v1.2.3-test   (ldflags injected)
$ tokui -v          # tokui version v1.2.3-test
$ tokui --version   # tokui version v0.10.1-...+dirty   (no ldflags, build-info fallback)
```

`golangci-lint run` and `make test` pass locally.