### PR TITLE
fix(cli): friendly error for non-existent or inaccessible path

### DIFF
--- a/cmd/app.go
+++ b/cmd/app.go
@@ -181,9 +181,9 @@ func runApp(cmd *cobra.Command, args []string) error {
 		// clear message instead of a raw provider failure and stack trace.
 		if _, statErr := os.Stat(analysisPath); statErr != nil {
 			switch {
-			case os.IsNotExist(statErr):
+			case errors.Is(statErr, os.ErrNotExist):
 				printError(fmt.Sprintf("Path %q does not exist. Please provide a valid file or directory to analyze.", analysisPath))
-			case os.IsPermission(statErr):
+			case errors.Is(statErr, os.ErrPermission):
 				printError(fmt.Sprintf("Permission denied accessing %q. Please check its permissions.", analysisPath))
 			default:
 				printError(fmt.Sprintf("Cannot access %q: %v", analysisPath, statErr))

--- a/cmd/app.go
+++ b/cmd/app.go
@@ -177,6 +177,20 @@ func runApp(cmd *cobra.Command, args []string) error {
 		}
 		analysisPath := filepath.Clean(root)
 
+		// Validate the path before shelling out to the provider so users get a
+		// clear message instead of a raw provider failure and stack trace.
+		if _, statErr := os.Stat(analysisPath); statErr != nil {
+			switch {
+			case os.IsNotExist(statErr):
+				printError(fmt.Sprintf("Path %q does not exist. Please provide a valid file or directory to analyze.", analysisPath))
+			case os.IsPermission(statErr):
+				printError(fmt.Sprintf("Permission denied accessing %q. Please check its permissions.", analysisPath))
+			default:
+				printError(fmt.Sprintf("Cannot access %q: %v", analysisPath, statErr))
+			}
+			os.Exit(1)
+		}
+
 		if err := tree.BuildFromProvider(p, analysisPath); err != nil {
 			// Provide a more friendly error message if the provider binary is not installed
 			if strings.Contains(err.Error(), "executable file not found") {


### PR DESCRIPTION
## Problem

Passing a non-existent directory to `tokui` in direct mode surfaced the raw provider failure plus a scary panic-style stack trace:

```
Error: error during analysis with tokei: tokei command execution failed (exit code 1): exit status 1
Standard error output:
Error: '/var/home/yiran/projects/promethe' not found.
...
😵 🚨 ⛔ Something went terribly wrong...
```

## Fix

Validate the analysis path with `os.Stat` **before** shelling out to the provider in direct mode. Users now get a clear, actionable message:

```
Path "/var/home/yiran/projects/promethe" does not exist. Please provide a valid file or directory to analyze.
```

Handled cases:
- **Not exist** → "Path … does not exist. Please provide a valid file or directory to analyze."
- **Permission denied** → "Permission denied accessing … Please check its permissions."
- **Other access errors** → "Cannot access …: <reason>"

The check runs before the provider call, so it works uniformly for both the **tokei** and **scc** backends, and follows the existing `printError` + `os.Exit(1)` pattern (no stack trace). Pipe mode and valid paths are unaffected.

## Testing

- `go build ./...`
- `go vet ./cmd/` and `go test ./cmd/` pass
- Verified `./bin/tokui ~/projects/promethe` prints the friendly message and exits 1